### PR TITLE
install textures too

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -7,3 +7,8 @@ install_subdir(
     'models',
     install_dir : join_paths([get_option('datadir'), 'vkmark'])
     )
+
+install_subdir(
+    'textures',
+    install_dir : join_paths([get_option('datadir'), 'vkmark'])
+    )


### PR DESCRIPTION
Fixes
```
[texture] anisotropy=0: Failed with exception: Failed to read image file /usr/share/vkmark/textures/crate-base.jpg: can't fopen
[texture] anisotropy=16: Failed with exception: Failed to read image file /usr/share/vkmark/textures/crate-base.jpg: can't fopen
```