### PR TITLE
Fix build against glm-0.9.9.6

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,8 @@ cpp = meson.get_compiler('cpp')
 
 vulkan_dep = cpp.find_library('vulkan')
 dl_dep = cpp.find_library('dl')
-glm_dep = dependency('glm')
+glm_dep = dependency('glm', required: false)
+glm_header = cpp.has_header('glm/glm.hpp', dependencies: glm_dep, required: true)
 assimp_dep = dependency('assimp')
 
 xcb_dep = dependency('xcb', required : get_option('xcb') == 'true')


### PR DESCRIPTION
The latest version of the `glm` package does not install the .pc file,
which is needed by meson to find the package. Therefore, we check for
the main header file to ensure glm is properly installed and can be used
to build `vkmark`.

Fixes #20 