### PR TITLE
wayland: Port to xdg-shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: >
         sudo apt install meson libvulkan-dev libglm-dev libassimp-dev
-        libxcb1-dev libxcb-icccm4-dev libwayland-dev
+        libxcb1-dev libxcb-icccm4-dev libwayland-dev wayland-protocols
         libdrm-dev libgbm-dev
     - name: Setup
       run: meson setup build

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ for the X11 backend:
 for the wayland backend:
 
  * libwayland-client and development files
+ * wayland-protocols >= 1.12
 
 for the KMS backend:
 
@@ -29,7 +30,7 @@ for the KMS backend:
 
 On a recent Debian/Ubuntu system you can get all the dependencies with:
 
- `$ sudo apt install meson libvulkan-dev libglm-dev libassimp-dev libxcb1-dev libxcb-icccm4-dev libwayland-dev libdrm-dev libgbm-dev`
+ `$ sudo apt install meson libvulkan-dev libglm-dev libassimp-dev libxcb1-dev libxcb-icccm4-dev libwayland-dev wayland-protocols libdrm-dev libgbm-dev`
 
 # Building and installing
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'vkmark',
-    'cpp',
+    ['cpp', 'c'],
     default_options : ['cpp_std=c++14'],
     version : '2017.08',
     meson_version: '>=0.45'
@@ -27,6 +27,9 @@ assimp_dep = dependency('assimp')
 xcb_dep = dependency('xcb', required : get_option('xcb') == 'true')
 xcb_icccm_dep = dependency('xcb-icccm', required : get_option('xcb') == 'true')
 wayland_client_dep = dependency('wayland-client', required : get_option('wayland') == 'true')
+wayland_protocols_dep = dependency('wayland-protocols', version : '>= 1.12',
+                                   required : get_option('wayland') == 'true')
+wayland_scanner_dep = dependency('wayland-scanner', required : get_option('wayland') == 'true')
 libdrm_dep = dependency('libdrm', required : get_option('kms') == 'true')
 gbm_dep = dependency('gbm', required : get_option('kms') == 'true')
 has_vulkan_intel_header = cpp.has_header('vulkan/vulkan_intel.h', dependencies: vulkan_dep)

--- a/src/meson.build
+++ b/src/meson.build
@@ -71,11 +71,30 @@ if build_xcb_ws
 endif
 
 if build_wayland_ws
+    wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))
+    wayland_protocols_dir = wayland_protocols_dep.get_pkgconfig_variable('pkgdatadir')
+
+    xdg_shell_xml_path = wayland_protocols_dir + '/stable/xdg-shell/xdg-shell.xml'
+    xdg_shell_client_header = custom_target(
+        'xdg-shell client-header',
+        command: [ wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@' ],
+        input: xdg_shell_xml_path,
+        output: 'xdg-shell-client-protocol.h',
+        )
+    xdg_shell_private_code = custom_target(
+        'xdg-shell private-code',
+        command: [ wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@' ],
+        input: xdg_shell_xml_path,
+        output: 'xdg-shell-protocol.c',
+        )
+
     wayland_ws = shared_module(
         'wayland',
         'ws/wayland_window_system_plugin.cpp',
         'ws/wayland_native_system.cpp',
         'ws/swapchain_window_system.cpp',
+        xdg_shell_client_header,
+        xdg_shell_private_code,
         dependencies : [vulkan_dep, wayland_client_dep],
         name_prefix : '',
         install : true,

--- a/src/ws/wayland_native_system.cpp
+++ b/src/ws/wayland_native_system.cpp
@@ -48,11 +48,6 @@ void handle_output_done(void* /*data*/, wl_output* /*wl_output*/)
 {
 }
 
-void handle_output_scale(
-    void* /*data*/, wl_output* /*wl_output*/, int32_t /*factor*/)
-{
-}
-
 void handle_keyboard_keymap(
     void* /*data*/, wl_keyboard* /*wl_keyboard*/, uint32_t /*format*/,
     int32_t /*fd*/, uint32_t /*size*/)
@@ -92,9 +87,9 @@ wl_seat_listener const WaylandNativeSystem::seat_listener{
 
 wl_output_listener const WaylandNativeSystem::output_listener{
     handle_output_geometry,
-    handle_output_mode,
+    WaylandNativeSystem::handle_output_mode,
     handle_output_done,
-    handle_output_scale
+    WaylandNativeSystem::handle_output_scale
 };
 
 wl_keyboard_listener const WaylandNativeSystem::keyboard_listener{
@@ -109,7 +104,12 @@ wl_keyboard_listener const WaylandNativeSystem::keyboard_listener{
 WaylandNativeSystem::WaylandNativeSystem(int width, int height)
     : requested_width{width},
       requested_height{height},
-      should_quit_{false}
+      should_quit_{false},
+      display_fd{0},
+      output_width{0},
+      output_height{0},
+      output_refresh{0},
+      output_scale{1}
 {
     create_native_window();
 }
@@ -229,6 +229,12 @@ void WaylandNativeSystem::create_native_window()
             static_cast<uint32_t>(requested_width),
             static_cast<uint32_t>(requested_height)};
     }
+
+    if (wl_proxy_get_version(reinterpret_cast<wl_proxy*>(output.raw)) >=
+        WL_OUTPUT_SCALE_SINCE_VERSION)
+    {
+        wl_surface_set_buffer_scale(surface, output_scale);
+    }
 }
 
 bool WaylandNativeSystem::fullscreen_requested()
@@ -246,7 +252,8 @@ void WaylandNativeSystem::handle_registry_global(
     if (interface == "wl_compositor")
     {
         auto compositor_raw = static_cast<wl_compositor*>(
-            wl_registry_bind(registry, id, &wl_compositor_interface, 1));
+            wl_registry_bind(registry, id, &wl_compositor_interface,
+                std::min(version, 4U)));
         wws->compositor = ManagedResource<wl_compositor*>{
             std::move(compositor_raw), wl_compositor_destroy};
     }
@@ -271,7 +278,8 @@ void WaylandNativeSystem::handle_registry_global(
         if (!wws->output)
         {
             auto output_raw = static_cast<wl_output*>(
-                wl_registry_bind(registry, id, &wl_output_interface, 1));
+                wl_registry_bind(registry, id, &wl_output_interface,
+                    std::min(version, 2U)));
             wws->output = ManagedResource<wl_output*>{
                 std::move(output_raw), wl_output_destroy};
 
@@ -312,6 +320,13 @@ void WaylandNativeSystem::handle_output_mode(
         wws->output_height = height;
         wws->output_refresh = refresh;
     }
+}
+
+void WaylandNativeSystem::handle_output_scale(
+    void* data, wl_output* /*output*/, int32_t factor)
+{
+    auto const wws = static_cast<WaylandNativeSystem*>(data);
+    wws->output_scale = factor;
 }
 
 void WaylandNativeSystem::handle_keyboard_key(

--- a/src/ws/wayland_native_system.cpp
+++ b/src/ws/wayland_native_system.cpp
@@ -235,6 +235,13 @@ void WaylandNativeSystem::create_native_window()
     {
         wl_surface_set_buffer_scale(surface, output_scale);
     }
+
+    auto const opaque_region = ManagedResource<wl_region*>{
+        wl_compositor_create_region(compositor), wl_region_destroy};
+    wl_region_add(opaque_region, 0, 0, vk_extent.width, vk_extent.height);
+    wl_surface_set_opaque_region(surface, opaque_region);
+
+    wl_surface_commit(surface);
 }
 
 bool WaylandNativeSystem::fullscreen_requested()

--- a/src/ws/wayland_native_system.h
+++ b/src/ws/wayland_native_system.h
@@ -24,6 +24,7 @@
 
 #define VK_USE_PLATFORM_WAYLAND_KHR
 #include "native_system.h"
+#include "xdg-shell-client-protocol.h"
 
 #include <wayland-client.h>
 
@@ -47,6 +48,8 @@ private:
     static void handle_registry_global(
         void* data, wl_registry* registry, uint32_t id,
         char const* interface, uint32_t version);
+    static void handle_xdg_toplevel_close(
+        void* data, xdg_toplevel* xdg_toplevel);
     static void handle_seat_capabilities(
         void* data, wl_seat* seat, uint32_t capabilities);
     static void handle_output_mode(
@@ -62,6 +65,9 @@ private:
     static wl_seat_listener const seat_listener;
     static wl_keyboard_listener const keyboard_listener;
     static wl_output_listener const output_listener;
+    static struct xdg_wm_base_listener const xdg_wm_base_listener;
+    static struct xdg_toplevel_listener const xdg_toplevel_listener;
+    static struct xdg_surface_listener const xdg_surface_listener;
 
     int const requested_width;
     int const requested_height;
@@ -69,12 +75,13 @@ private:
 
     ManagedResource<wl_display*> display;
     ManagedResource<wl_compositor*> compositor;
-    ManagedResource<wl_shell*> shell;
+    ManagedResource<struct xdg_wm_base*> xdg_wm_base;
     ManagedResource<wl_seat*> seat;
     ManagedResource<wl_output*> output;
     ManagedResource<wl_keyboard*> keyboard;
     ManagedResource<wl_surface*> surface;
-    ManagedResource<wl_shell_surface*> shell_surface;
+    ManagedResource<struct xdg_surface*> xdg_surface;
+    ManagedResource<struct xdg_toplevel*> xdg_toplevel;
     int display_fd;
     int32_t output_width;
     int32_t output_height;

--- a/src/ws/wayland_native_system.h
+++ b/src/ws/wayland_native_system.h
@@ -52,6 +52,8 @@ private:
     static void handle_output_mode(
         void* data, wl_output* output,
         uint32_t flags, int32_t width, int32_t height, int32_t refresh);
+    static void handle_output_scale(
+        void* data, wl_output* output, int32_t factor);
     static void handle_keyboard_key(
         void* data, wl_keyboard* wl_keyboard,
         uint32_t serial, uint32_t time,
@@ -77,5 +79,6 @@ private:
     int32_t output_width;
     int32_t output_height;
     int32_t output_refresh;
+    int32_t output_scale;
     vk::Extent2D vk_extent;
 };


### PR DESCRIPTION
wl_shell is obsolete and even unsupported by some wayland servers. Use the newer xdg-shell extension for window management.