### PR TITLE
Added explicit gpu choice and some responsibility fixes in VulkanState

### DIFF
--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <array>
+#include <vulkan/vulkan.hpp>
+
+using DeviceUUID = std::array<unsigned char, VK_UUID_SIZE>;
+
+template<std::size_t Size>
+constexpr std::array<char, 2 * Size + 1> decode_UUID(const std::array<unsigned char, Size>& bytes)
+{
+    std::array<char, 2 * Size + 1> representation;
+    constexpr char characters[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        auto& byte = bytes[i];
+
+        representation[2 * i] = characters[byte / 16];
+        representation[2 * i + 1] = characters[byte % 16];
+    }
+    representation.back() = '\0';
+
+    return representation;
+}
+
+template<std::size_t Size>
+constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 * Size + 1>& representation)
+{
+    std::array<unsigned char, Size> bytes;
+
+    auto&& from_character = [](const char ch){
+        if (ch >= '0' && ch <= '9')
+            return ch - '0';
+        else if (ch >= 'a' && ch <= 'f')
+            return ch - 'a' + 10;
+        throw std::invalid_argument(std::string{ch} + "character found while parsing hexadecimal string!");
+    };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        bytes[i] = from_character(representation[2 * i]) * 16 + from_character(representation[2 * i + 1]);
+    }
+
+    return bytes;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,8 +115,8 @@ try
 
     auto& ws = ws_loader.load_window_system();
 
-    auto vulkan = options.use_device_with_index.second ?
-        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_index.first}} :
+    auto vulkan = options.use_device_with_uuid.second ?
+        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_uuid.first}} :
         VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,8 +113,20 @@ try
         return 0;
     }
 
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosed_strategy;
+    if (options.use_device_with_index.second)
+        choosed_strategy = std::make_unique<ChooseIndexPhysicalDevice>(options.use_device_with_index.first);
+    else
+        choosed_strategy = std::make_unique<ChooseFirstSupportedPhysicalDevice>();
+
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choosed_strategy.get()};
+
+    if (options.list_devices)
+    {
+        log_info(vulkan.instance().enumeratePhysicalDevices());
+        return 0;
+    }
 
     auto const ws_vulkan_deinit = Util::on_scope_exit([&] { ws.deinit_vulkan(); });
     ws.init_vulkan(vulkan);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ try
     auto& ws = ws_loader.load_window_system();
 
     auto vulkan = options.use_device_with_index.second ?
-        VulkanState{ws.vulkan_wsi(), ChooseByIndexStrategy{options.use_device_with_index.first}} :
+        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_index.first}} :
         VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,14 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosen_strategy;
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choose_physical_device_strategy;
     if (options.use_device_with_index.second)
-        choosen_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
+        choose_physical_device_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
     else
-        choosen_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
+        choose_physical_device_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
 
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choosen_strategy.get()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choose_physical_device_strategy.get()};
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,11 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choose_physical_device_strategy;
-    if (options.use_device_with_index.second)
-        choose_physical_device_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
-    else
-        choose_physical_device_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
-
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choose_physical_device_strategy.get()};
+
+    auto vulkan = options.use_device_with_index.second ?
+        VulkanState{ws.vulkan_wsi(), ChooseByIndexStrategy{options.use_device_with_index.first}} :
+        VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,14 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosed_strategy;
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosen_strategy;
     if (options.use_device_with_index.second)
-        choosed_strategy = std::make_unique<ChooseIndexPhysicalDevice>(options.use_device_with_index.first);
+        choosen_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
     else
-        choosed_strategy = std::make_unique<ChooseFirstSupportedPhysicalDevice>();
+        choosen_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
 
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choosed_strategy.get()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choosen_strategy.get()};
 
     if (options.list_devices)
     {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -166,7 +166,7 @@ std::string Options::help_string()
         "      --run-forever           Run indefinitely, looping from the last benchmark\n"
         "                              back to the first\n"
         "  -d, --debug                 Display debug messages\n"
-        "  -D  --use-device            Use Vulkan device with index as in list\n"
+        "  -D  --use-device            Use Vulkan device with specified UUID\n"
         "  -L  --list-devices          List Vulkan devices\n"
         "  -h, --help                  Display help\n";
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -20,10 +20,15 @@
  *   Alexandros Frantzis <alexandros.frantzis@collabora.com>
  */
 
+#include <array>
+#include <bits/getopt_core.h>
 #include <cstdio>
+#include <cstring>
 #include <getopt.h>
 #include <algorithm>
 #include <cctype>
+#include <string>
+#include <vulkan/vulkan_core.h>
 
 #include "options.h"
 #include "util.h"
@@ -137,7 +142,7 @@ Options::Options()
       show_debug{false},
       show_help{false},
       list_devices{false},
-      use_device_with_index{}
+      use_device_with_uuid{}
 {
 }
 
@@ -228,7 +233,16 @@ bool Options::parse_args(int argc, char **argv)
         else if (c == 'L' || optname == "list-devices")
             list_devices = true;
         else if (c == 'D' || optname == "use-device")
-            use_device_with_index = std::make_pair(static_cast<uint32_t>(std::stoi(optarg)), true);
+        {
+            std::string formated_argument{optarg};
+            formated_argument.resize(2 * VK_UUID_SIZE + 1);
+            formated_argument.back() = '\0';
+            
+            std::array<char, 2 * VK_UUID_SIZE + 1> representation;
+            std::copy(formated_argument.cbegin(), formated_argument.cend(), representation.begin());
+
+            use_device_with_uuid = std::make_pair(encode_UUID<VK_UUID_SIZE>(representation), true);
+        }
     }
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,6 +36,7 @@ namespace
 struct option long_options[] = {
     {"benchmark", 1, 0, 0},
     {"size", 1, 0, 0},
+    {"force-device", 1, 0, 0},
     {"fullscreen", 0, 0, 0},
     {"present-mode", 1, 0, 0},
     {"pixel-format", 1, 0, 0},
@@ -133,7 +134,9 @@ Options::Options()
       data_dir{VKMARK_DATA_DIR},
       run_forever{false},
       show_debug{false},
-      show_help{false}
+      show_help{false},
+      list_devices{false},
+      use_device_with_index{}
 {
 }
 
@@ -162,6 +165,8 @@ std::string Options::help_string()
         "      --run-forever           Run indefinitely, looping from the last benchmark\n"
         "                              back to the first\n"
         "  -d, --debug                 Display debug messages\n"
+        "  -D  --use-device            Use Vulkan device with index as in list\n"
+        "  -L  --list-devices          List Vulkan devices\n"
         "  -h, --help                  Display help\n";
 
     for (auto const& wsh : window_system_help)
@@ -181,7 +186,7 @@ bool Options::parse_args(int argc, char **argv)
         int c;
         std::string optname;
 
-        c = getopt_long(argc, argv, "b:s:p:ldh",
+        c = getopt_long(argc, argv, "b:s:p:ldhD:L",
                         long_options, &option_index);
         if (c == -1)
             break;
@@ -219,6 +224,10 @@ bool Options::parse_args(int argc, char **argv)
             show_debug = true;
         else if (c == 'h' || optname == "help")
             show_help = true;
+        else if (c == 'L' || optname == "list-devices")
+            list_devices = true;
+        else if (c == 'D' || optname == "use-device")
+            use_device_with_index = std::make_pair(static_cast<uint32_t>(std::stoi(optarg)), true);
     }
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -46,6 +46,7 @@ struct option long_options[] = {
     {"data-dir", 1, 0, 0},
     {"winsys", 1, 0, 0},
     {"winsys-options", 1, 0, 0},
+    {"list-devices", 0, 0, 0},
     {"run-forever", 0, 0, 0},
     {"debug", 0, 0, 0},
     {"help", 0, 0, 0},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,7 +36,7 @@ namespace
 struct option long_options[] = {
     {"benchmark", 1, 0, 0},
     {"size", 1, 0, 0},
-    {"force-device", 1, 0, 0},
+    {"use-device", 1, 0, 0},
     {"fullscreen", 0, 0, 0},
     {"present-mode", 1, 0, 0},
     {"pixel-format", 1, 0, 0},

--- a/src/options.h
+++ b/src/options.h
@@ -55,6 +55,8 @@ struct Options
     bool run_forever;
     bool show_debug;
     bool show_help;
+    bool list_devices;
+    std::pair<uint32_t, bool> use_device_with_index; // pseudo-optional
 
 private:
     std::vector<std::string> window_system_help;

--- a/src/options.h
+++ b/src/options.h
@@ -28,6 +28,8 @@
 
 #include <vulkan/vulkan.hpp>
 
+#include "device_uuid.h"
+
 struct Options
 {
     struct WindowSystemOption
@@ -56,7 +58,7 @@ struct Options
     bool show_debug;
     bool show_help;
     bool list_devices;
-    std::pair<uint32_t, bool> use_device_with_index; // pseudo-optional
+    std::pair<DeviceUUID, bool> use_device_with_uuid; // pseudo-optional
 
 private:
     std::vector<std::string> window_system_help;

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -181,9 +181,6 @@ void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWS
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 
-    // TODO: move to print list of physical devices
-    // Log::debug("Found %d physical devices\n", physical_devices.size());
-
     Log::debug("Trying to use device with specified index %d.\n", use_physical_device_index);
 
     if (use_physical_device_index < physical_devices.size())

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -215,9 +215,7 @@ void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& v
         Log::warning("Device with index %d does not exist!\n", physical_device_index);
 
     if(!vk_physical_device)
-    {
        throw std::runtime_error("Could not use device with index " + std::to_string(physical_device_index) + "!\n");
-    }
 
     Log::debug("Device with index %d succesfully choosen!\n", physical_device_index);
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -141,7 +141,7 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-void ChooseFirstSupportedPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     Log::debug("Trying to use first supported device.\n");
 
@@ -177,15 +177,15 @@ void ChooseFirstSupportedPhysicalDevice::choose(vk::Instance const& vk_instance,
     Log::debug("First supported device choosen!\n");
 }
 
-void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 
-    Log::debug("Trying to use device with specified index %d.\n", use_physical_device_index);
+    Log::debug("Trying to use device with specified index %d.\n", physical_device_index);
 
-    if (use_physical_device_index < physical_devices.size())
+    if (physical_device_index < physical_devices.size())
     {
-        auto const pd = physical_devices[use_physical_device_index];
+        auto const pd = physical_devices[physical_device_index];
 
         if (vulkan_wsi.is_physical_device_supported(pd))
         {
@@ -212,12 +212,12 @@ void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWS
         
     }
     else
-        Log::warning("Device with index %d does not exist!\n", use_physical_device_index);
+        Log::warning("Device with index %d does not exist!\n", physical_device_index);
 
     if(!vk_physical_device)
     {
-       throw std::runtime_error("Could not use device with index " + std::to_string(use_physical_device_index) + "!\n");
+       throw std::runtime_error("Could not use device with index " + std::to_string(physical_device_index) + "!\n");
     }
 
-    Log::debug("Device with index %d succesfully choosen!\n", use_physical_device_index);
+    Log::debug("Device with index %d succesfully choosen!\n", physical_device_index);
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -47,18 +47,6 @@ void log_info(std::vector<vk::PhysicalDevice> const& physical_devices)
     }
 }
 
-VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy& choose_physical_device_strategy)
-{
-    create_instance(vulkan_wsi);
-
-    choose_physical_device_strategy.choose(instance(), vulkan_wsi);
-    vk_physical_device = choose_physical_device_strategy.physical_device();
-    vk_graphics_queue_family_index = choose_physical_device_strategy.graphics_queue_family_index();
-
-    create_device(vulkan_wsi);
-    create_command_pool();
-}
-
 void VulkanState::create_instance(VulkanWSI& vulkan_wsi)
 {
     auto const app_info = vk::ApplicationInfo{}
@@ -141,7 +129,7 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseFirstSupportedStrategy::operator()(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     Log::debug("Trying to use first supported device.\n");
 
@@ -177,7 +165,7 @@ void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, Vulka
     Log::debug("First supported device choosen!\n");
 }
 
-void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseByIndexStrategy::operator()(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -34,7 +34,7 @@ class VulkanState
 {
 public:
     template <typename ChoosePhysicalDeviceStrategy>
-    inline VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy choose_physical_device_strategy)
+    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy choose_physical_device_strategy)
     {
         create_instance(vulkan_wsi);
 
@@ -46,7 +46,7 @@ public:
         create_command_pool();
     }
 
-    inline void log_info()
+    void log_info()
     {
         ::log_info(physical_device());
     }
@@ -102,12 +102,12 @@ class ChooseFirstSupportedStrategy
 public:
     ~ChooseFirstSupportedStrategy(){};
 
-    inline vk::PhysicalDevice const& physical_device() const noexcept
+    vk::PhysicalDevice const& physical_device() const noexcept
     {
         return vk_physical_device;
     }
 
-    inline uint32_t const& graphics_queue_family_index() const noexcept
+    uint32_t const& graphics_queue_family_index() const noexcept
     {
         return vk_graphics_queue_family_index;
     }
@@ -122,7 +122,7 @@ public:
 class ChooseByIndexStrategy : public ChooseFirstSupportedStrategy
 {
 public:
-    inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
+    ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
         : physical_device_index(use_physical_device_with_index)
     {}
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
-#include <optional>
 
 #include "managed_resource.h"
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -118,9 +118,8 @@ class ChooseByIndexStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
     inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
-    {
-        physical_device_index = use_physical_device_with_index;
-    }
+        : physical_device_index(use_physical_device_with_index)
+    {}
 
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -79,9 +79,8 @@ private:
 
     ManagedResource<vk::Instance> vk_instance;
     ManagedResource<vk::Device> vk_device;
-    vk::Queue vk_graphics_queue;
     ManagedResource<vk::CommandPool> vk_command_pool;
-    std::pair<size_t, bool> force_physical_device; // pseudo-optional
+    vk::Queue vk_graphics_queue;
     vk::PhysicalDevice vk_physical_device;
     uint32_t vk_graphics_queue_family_index;
     

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -110,22 +110,22 @@ protected:
     uint32_t vk_graphics_queue_family_index;
 };
 
-class ChooseFirstSupportedPhysicalDevice : public ChoosePhysicalDeviceStrategy
+class ChooseFirstSupportedStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 };
 
-class ChooseIndexPhysicalDevice : public ChoosePhysicalDeviceStrategy
+class ChooseByIndexStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
-    inline ChooseIndexPhysicalDevice(uint32_t use_physical_device_index)
+    inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
     {
-        this->use_physical_device_index = use_physical_device_index;
+        physical_device_index = use_physical_device_with_index;
     }
 
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 
 private:
-    uint32_t use_physical_device_index;
+    uint32_t physical_device_index;
 };

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -26,6 +26,7 @@
 
 #include "vulkan_wsi.h"
 #include "managed_resource.h"
+#include "device_uuid.h"
 
 class VulkanWSI;
 void log_info(vk::PhysicalDevice const& physical_device);
@@ -117,12 +118,12 @@ public:
 class ChooseByUUIDStrategy
 {
 public:
-    ChooseByUUIDStrategy(uint32_t use_physical_device_with_index)
-        : m_selected_device_index(use_physical_device_with_index)
+    ChooseByUUIDStrategy(const DeviceUUID& uuid)
+        : m_selected_device_uuid(uuid)
     {}
 
     vk::PhysicalDevice operator()(std::vector<vk::PhysicalDevice> avaiable_devices);
 
 private:
-    uint32_t m_selected_device_index;
+    DeviceUUID m_selected_device_uuid;
 };


### PR DESCRIPTION
Hello

In my computer there are multiple GPUs. Integrated Intel gpu and dedicated Amd GPU. I wanted to test them both...

I moved responsibility of choosing GPU from VulkanState to specialised strategy classes and wrote some functionality to explicitly select GPU i want to use.

This should close https://github.com/vkmark/vkmark/issues/10 and probably https://github.com/vkmark/vkmark/issues/2 (As far as i know DRI_PRIME is for Mesa/OpenGL applications only, Vulkan needs explicit choice but in exchange allows for GPU cooperation)

Here is my log:
```
$ vkmark -L
=== Physical Device 0. ===
    Vendor ID:      0x8086
    Device ID:      0x1912
    Device Name:    Intel(R) HD Graphics 530 (SKL GT2)
    Driver Version: 83890178
=== Physical Device 1. ===
    Vendor ID:      0x1002
    Device ID:      0x731F
    Device Name:    AMD RADV NAVI10 (LLVM 10.0.0)
    Driver Version: 83890178

$ vkmark -D 0
=======================================================
    vkmark 2017.08
=======================================================
    Vendor ID:      0x8086
    Device ID:      0x1912
    Device Name:    Intel(R) HD Graphics 530 (SKL GT2)
    Driver Version: 83890178
=======================================================
[vertex] device-local=true:^C FPS: 1642 FrameTime: 0.609 ms
=======================================================
                                   vkmark Score: 1642
=======================================================

$ vkmark -D 1
=======================================================
    vkmark 2017.08
=======================================================
    Vendor ID:      0x1002
    Device ID:      0x731F
    Device Name:    AMD RADV NAVI10 (LLVM 10.0.0)
    Driver Version: 83890178
=======================================================
[vertex] device-local=true:^C FPS: 23943 FrameTime: 0.042 ms
=======================================================
                                   vkmark Score: 23943
=======================================================
```