### PR TITLE
kms: unbreak on FreeBSD

### DIFF
--- a/src/ws/kms_window_system.cpp
+++ b/src/ws/kms_window_system.cpp
@@ -251,7 +251,7 @@ ManagedResource<gbm_device*> create_gbm_device(int drm_fd)
 
 ManagedResource<int> open_active_vt()
 {
-    auto fd = open("/dev/tty0", O_RDONLY);
+    auto fd = open("/dev/tty", O_RDONLY);
     if (fd < 0)
         throw std::runtime_error{"Failed to open active VT"};
 
@@ -281,7 +281,7 @@ VTState::VTState()
             errno, std::system_category(), "Failed to get VT control mode"};
     }
 
-    vt_mode const vtm{VT_PROCESS, 0, 0, 0, 0};
+    vt_mode const vtm{VT_PROCESS, 0, SIGUSR1, SIGUSR2, SIGIO};
 
     if (ioctl(vt_fd, VT_SETMODE, &vtm) < 0)
     {

--- a/src/ws/kms_window_system.h
+++ b/src/ws/kms_window_system.h
@@ -30,7 +30,13 @@
 
 #include <xf86drmMode.h>
 #include <gbm.h>
+#if __has_include(<sys/consio.h>) // DragonFly, FreeBSD
+#include <sys/consio.h>
+#elif __has_include(<dev/wscons/wsdisplay_usl_io.h>) // NetBSD, OpenBSD
+#include <dev/wscons/wsdisplay_usl_io.h>
+#else
 #include <linux/vt.h>
+#endif
 
 class VTState
 {


### PR DESCRIPTION
- `struct vt_mode` is defined in a different header
- `VT_SETMODE` requires `relsig`, `acqsig` and (unused) `frsig` set to valid signals
- `/dev/tty0` is like `/dev/ttyv0` but without `VT_ACTIVATE` may simplify to `/dev/tty`
