### PR TITLE
multi gpu selection support

### DIFF
--- a/src/device_uuid.cpp
+++ b/src/device_uuid.cpp
@@ -1,0 +1,60 @@
+#include "device_uuid.h"
+#include <stdexcept>
+
+static std::array<char, 2 * VK_UUID_SIZE> decode_UUID(const std::array<uint8_t, VK_UUID_SIZE>& bytes)
+{
+    std::array<char, 2 * VK_UUID_SIZE> representation{};
+    constexpr char characters[16] = 
+        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        auto& byte = bytes[i];
+
+        representation[2 * i] = characters[byte / 16];
+        representation[2 * i + 1] = characters[byte % 16];
+    }
+
+    return representation;
+}
+
+static std::array<uint8_t, VK_UUID_SIZE> encode_UUID(const std::array<char, 2 * VK_UUID_SIZE>& representation)
+{
+    std::array<uint8_t, VK_UUID_SIZE> bytes{};
+
+    auto&& decode_character = [](const char ch) {
+        if (ch >= '0' && ch <= '9')
+            return ch - '0';
+        else if (ch >= 'a' && ch <= 'f')
+            return ch - 'a' + 10;
+        throw std::invalid_argument(
+            std::string{ch} + "character found while parsing hexadecimal string!");
+    };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        bytes[i] = decode_character(representation[2 * i]) * 16
+            + decode_character(representation[2 * i + 1]);
+    }
+
+    return bytes;
+}
+
+DeviceUUID::DeviceUUID(std::string const& representation)
+{
+    std::array<char, 2 * VK_UUID_SIZE> chars{};
+    if (representation.size() != chars.size())
+        throw std::invalid_argument("given UUID representation has wrong size!");
+
+    std::copy(representation.begin(), representation.end(), chars.begin());
+    raw = encode_UUID(chars);
+}
+
+std::array<char, 2 * VK_UUID_SIZE + 1> DeviceUUID::representation() const
+{
+    std::array<char, 2 * VK_UUID_SIZE + 1> c_str{};
+    auto&& chars = decode_UUID(raw);
+    std::copy(chars.begin(), chars.end(), c_str.begin());
+
+    return c_str;
+}

--- a/src/device_uuid.cpp
+++ b/src/device_uuid.cpp
@@ -27,7 +27,8 @@ static std::array<uint8_t, VK_UUID_SIZE> encode_UUID(const std::array<char, 2 * 
             return ch - '0';
         else if (ch >= 'a' && ch <= 'f')
             return ch - 'a' + 10;
-        throw std::invalid_argument(
+        else 
+            throw std::invalid_argument(
             std::string{ch} + "character found while parsing hexadecimal string!");
     };
 

--- a/src/device_uuid.cpp
+++ b/src/device_uuid.cpp
@@ -27,8 +27,7 @@ static std::array<uint8_t, VK_UUID_SIZE> encode_UUID(const std::array<char, 2 * 
             return ch - '0';
         else if (ch >= 'a' && ch <= 'f')
             return ch - 'a' + 10;
-        else 
-            throw std::invalid_argument(
+        throw std::invalid_argument(
             std::string{ch} + "character found while parsing hexadecimal string!");
     };
 

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -59,10 +59,10 @@ struct DeviceUUID
         : raw(bytes)
     {}
 
-    // DeviceUUID(const uint8_t bytes[])
-    // {
-    //     std::copy(bytes, bytes + 16, raw.data());
-    // }
+    DeviceUUID(const uint8_t bytes[])
+    {
+        std::copy(bytes, bytes + 16, raw.data());
+    }
 
     DeviceUUID(std::string const& representation)
     {

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -1,15 +1,18 @@
 #pragma once
 
 #include <array>
+#include <stdexcept>
+#include <string>
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_core.h>
 
-using DeviceUUID = std::array<unsigned char, VK_UUID_SIZE>;
 
 template<std::size_t Size>
-constexpr std::array<char, 2 * Size + 1> decode_UUID(const std::array<unsigned char, Size>& bytes)
+constexpr std::array<char, 2 * Size> decode_UUID(const std::array<unsigned char, Size>& bytes)
 {
-    std::array<char, 2 * Size + 1> representation;
-    constexpr char characters[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    std::array<char, 2 * Size> representation;
+    constexpr char characters[16] = 
+        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
     for (std::size_t i = 0; i < bytes.size(); ++i)
     {
@@ -18,28 +21,65 @@ constexpr std::array<char, 2 * Size + 1> decode_UUID(const std::array<unsigned c
         representation[2 * i] = characters[byte / 16];
         representation[2 * i + 1] = characters[byte % 16];
     }
-    representation.back() = '\0';
 
     return representation;
 }
 
 template<std::size_t Size>
-constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 * Size + 1>& representation)
+constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 * Size>& representation)
 {
     std::array<unsigned char, Size> bytes;
 
-    auto&& from_character = [](const char ch){
+    auto&& decode_character = [](const char ch){
         if (ch >= '0' && ch <= '9')
             return ch - '0';
         else if (ch >= 'a' && ch <= 'f')
             return ch - 'a' + 10;
-        throw std::invalid_argument(std::string{ch} + "character found while parsing hexadecimal string!");
+        throw std::invalid_argument(
+            std::string{ch} + "character found while parsing hexadecimal string!");
     };
 
     for (std::size_t i = 0; i < bytes.size(); ++i)
     {
-        bytes[i] = from_character(representation[2 * i]) * 16 + from_character(representation[2 * i + 1]);
+        bytes[i] = decode_character(representation[2 * i]) * 16
+            + decode_character(representation[2 * i + 1]);
     }
 
     return bytes;
 }
+
+struct DeviceUUID
+{
+    std::array<unsigned char, VK_UUID_SIZE> raw;
+    
+    DeviceUUID() = default;
+    DeviceUUID(std::array<unsigned char, VK_UUID_SIZE> const& bytes)
+        : raw(bytes)
+    {}
+    DeviceUUID(std::string const& representation)
+    {
+        std::array<char, 2 * VK_UUID_SIZE> chars;
+        if (representation.size() != chars.size())
+            throw std::invalid_argument("given UUID representation has wrong size!");
+
+        std::copy(representation.begin(), representation.end(), chars.begin());
+        raw = encode_UUID<chars.size() / 2>(chars);
+    }
+
+    operator std::array<unsigned char, VK_UUID_SIZE> () const 
+    {
+        return raw;
+    }
+
+    operator std::string () const
+    {
+        auto&& chars = decode_UUID(raw);
+        return std::string(chars.begin(), chars.end());
+    }
+
+    bool operator==(const DeviceUUID& other)
+    {
+        return raw == other.raw;
+    } 
+
+};

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -59,10 +59,10 @@ struct DeviceUUID
         : raw(bytes)
     {}
 
-    DeviceUUID(const uint8_t bytes[])
-    {
-        std::copy(bytes, bytes + 16, raw.data());
-    }
+    // DeviceUUID(const uint8_t bytes[])
+    // {
+    //     std::copy(bytes, bytes + 16, raw.data());
+    // }
 
     DeviceUUID(std::string const& representation)
     {

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -1,54 +1,10 @@
 #pragma once
 
 #include <array>
-#include <stdexcept>
 #include <cstdint>
 #include <string>
 #include <vulkan/vulkan.hpp>
 
-
-namespace {
-
-inline std::array<char, 2 * VK_UUID_SIZE> decode_UUID(const std::array<uint8_t, VK_UUID_SIZE>& bytes)
-{
-    std::array<char, 2 * VK_UUID_SIZE> representation{};
-    constexpr char characters[16] = 
-        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-
-    for (std::size_t i = 0; i < bytes.size(); ++i)
-    {
-        auto& byte = bytes[i];
-
-        representation[2 * i] = characters[byte / 16];
-        representation[2 * i + 1] = characters[byte % 16];
-    }
-
-    return representation;
-}
-
-inline std::array<uint8_t, VK_UUID_SIZE> encode_UUID(const std::array<char, 2 * VK_UUID_SIZE>& representation)
-{
-    std::array<uint8_t, VK_UUID_SIZE> bytes{};
-
-    auto&& decode_character = [](const char ch) {
-        if (ch >= '0' && ch <= '9')
-            return ch - '0';
-        else if (ch >= 'a' && ch <= 'f')
-            return ch - 'a' + 10;
-        throw std::invalid_argument(
-            std::string{ch} + "character found while parsing hexadecimal string!");
-    };
-
-    for (std::size_t i = 0; i < bytes.size(); ++i)
-    {
-        bytes[i] = decode_character(representation[2 * i]) * 16
-            + decode_character(representation[2 * i + 1]);
-    }
-
-    return bytes;
-}
-
-}
 
 struct DeviceUUID
 {
@@ -59,19 +15,11 @@ struct DeviceUUID
         : raw(bytes)
     {}
 
+    DeviceUUID(std::string const& representation);
+
     DeviceUUID(const uint8_t bytes[]) // TODO: only used for githubs CI. delete when not needed anymore
     {
         std::copy(bytes, bytes + VK_UUID_SIZE, raw.data());
-    }
-
-    DeviceUUID(std::string const& representation)
-    {
-        std::array<char, 2 * VK_UUID_SIZE> chars{};
-        if (representation.size() != chars.size())
-            throw std::invalid_argument("given UUID representation has wrong size!");
-
-        std::copy(representation.begin(), representation.end(), chars.begin());
-        raw = encode_UUID(chars);
     }
 
     operator std::array<uint8_t, VK_UUID_SIZE> () const 
@@ -84,13 +32,5 @@ struct DeviceUUID
         return raw == other.raw;
     } 
 
-    std::array<char, 2 * VK_UUID_SIZE + 1> representation() const 
-    {
-        std::array<char, 2 * VK_UUID_SIZE + 1> c_str{};
-        auto&& chars = decode_UUID(raw);
-        std::copy(chars.begin(), chars.end(), c_str.begin());
-
-        return c_str;
-    }
-
+    std::array<char, 2 * VK_UUID_SIZE + 1> representation() const;
 };

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -7,10 +7,11 @@
 #include <vulkan/vulkan.hpp>
 
 
-template<std::size_t Size>
-constexpr std::array<char, 2 * Size> decode_UUID(const std::array<uint8_t, Size>& bytes)
+namespace {
+
+inline std::array<char, 2 * VK_UUID_SIZE> decode_UUID(const std::array<uint8_t, VK_UUID_SIZE>& bytes)
 {
-    std::array<char, 2 * Size> representation{};
+    std::array<char, 2 * VK_UUID_SIZE> representation{};
     constexpr char characters[16] = 
         { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
@@ -25,12 +26,11 @@ constexpr std::array<char, 2 * Size> decode_UUID(const std::array<uint8_t, Size>
     return representation;
 }
 
-template<std::size_t Size>
-constexpr std::array<uint8_t, Size> encode_UUID(const std::array<char, 2 * Size>& representation)
+inline std::array<uint8_t, VK_UUID_SIZE> encode_UUID(const std::array<char, 2 * VK_UUID_SIZE>& representation)
 {
-    std::array<uint8_t, Size> bytes{};
+    std::array<uint8_t, VK_UUID_SIZE> bytes{};
 
-    auto&& decode_character = [](const char ch){
+    auto&& decode_character = [](const char ch) {
         if (ch >= '0' && ch <= '9')
             return ch - '0';
         else if (ch >= 'a' && ch <= 'f')
@@ -46,6 +46,8 @@ constexpr std::array<uint8_t, Size> encode_UUID(const std::array<char, 2 * Size>
     }
 
     return bytes;
+}
+
 }
 
 struct DeviceUUID
@@ -69,7 +71,7 @@ struct DeviceUUID
             throw std::invalid_argument("given UUID representation has wrong size!");
 
         std::copy(representation.begin(), representation.end(), chars.begin());
-        raw = encode_UUID<chars.size() / 2>(chars);
+        raw = encode_UUID(chars);
     }
 
     operator std::array<uint8_t, VK_UUID_SIZE> () const 

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -59,7 +59,7 @@ struct DeviceUUID
         : raw(bytes)
     {}
 
-    DeviceUUID(const uint8_t bytes[])
+    DeviceUUID(const uint8_t bytes[]) // TODO: only used for githubs CI. delete when not needed anymore
     {
         std::copy(bytes, bytes + 16, raw.data());
     }

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -61,7 +61,7 @@ struct DeviceUUID
 
     DeviceUUID(const uint8_t bytes[]) // TODO: only used for githubs CI. delete when not needed anymore
     {
-        std::copy(bytes, bytes + 16, raw.data());
+        std::copy(bytes, bytes + VK_UUID_SIZE, raw.data());
     }
 
     DeviceUUID(std::string const& representation)

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <array>
+#include <vulkan/vulkan.hpp>
+
+using DeviceUUID = std::array<unsigned char, VK_UUID_SIZE>;
+
+template<std::size_t Size>
+constexpr std::array<char, 2 * Size + 1> decode_UUID(const std::array<unsigned char, Size>& bytes)
+{
+    std::array<char, 2 * Size + 1> representation;
+    constexpr char characters[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        auto& byte = bytes[i];
+
+        representation[2 * i] = characters[byte / 16];
+        representation[2 * i + 1] = characters[byte % 16];
+    }
+    representation.back() = '\0';
+
+    return representation;
+}
+
+template<std::size_t Size>
+constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 * Size + 1>& representation)
+{
+    std::array<unsigned char, Size> bytes;
+
+    auto&& from_character = [](const char ch){
+        if (ch >= '0' && ch <= '9')
+            return ch - '0';
+        else if (ch >= 'a' && ch <= 'f')
+            return ch - 'a' + 10;
+        throw std::invalid_argument(std::string{ch} + "character found while parsing hexadecimal string!");
+    };
+
+    for (std::size_t i = 0; i < bytes.size(); ++i)
+    {
+        bytes[i] = from_character(representation[2 * i]) * 16 + from_character(representation[2 * i + 1]);
+    }
+
+    return bytes;
+}

--- a/src/device_uuid.h
+++ b/src/device_uuid.h
@@ -4,13 +4,12 @@
 #include <stdexcept>
 #include <string>
 #include <vulkan/vulkan.hpp>
-#include <vulkan/vulkan_core.h>
 
 
 template<std::size_t Size>
 constexpr std::array<char, 2 * Size> decode_UUID(const std::array<unsigned char, Size>& bytes)
 {
-    std::array<char, 2 * Size> representation;
+    std::array<char, 2 * Size> representation{};
     constexpr char characters[16] = 
         { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
@@ -28,7 +27,7 @@ constexpr std::array<char, 2 * Size> decode_UUID(const std::array<unsigned char,
 template<std::size_t Size>
 constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 * Size>& representation)
 {
-    std::array<unsigned char, Size> bytes;
+    std::array<unsigned char, Size> bytes{};
 
     auto&& decode_character = [](const char ch){
         if (ch >= '0' && ch <= '9')
@@ -50,7 +49,7 @@ constexpr std::array<unsigned char, Size> encode_UUID(const std::array<char, 2 *
 
 struct DeviceUUID
 {
-    std::array<unsigned char, VK_UUID_SIZE> raw;
+    std::array<unsigned char, VK_UUID_SIZE> raw{};
     
     DeviceUUID() = default;
     DeviceUUID(std::array<unsigned char, VK_UUID_SIZE> const& bytes)
@@ -58,7 +57,7 @@ struct DeviceUUID
     {}
     DeviceUUID(std::string const& representation)
     {
-        std::array<char, 2 * VK_UUID_SIZE> chars;
+        std::array<char, 2 * VK_UUID_SIZE> chars{};
         if (representation.size() != chars.size())
             throw std::invalid_argument("given UUID representation has wrong size!");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,9 +116,10 @@ try
 
     auto& ws = ws_loader.load_window_system();
 
-    auto vulkan = options.use_device_with_uuid.second ?
-        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_uuid.first}} :
-        VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
+    auto&& device_strategy = options.use_device_with_uuid.second ?
+        VulkanState::ChoosePhysicalDeviceStrategy{ChooseByUUIDStrategy{options.use_device_with_uuid.first}} :
+        VulkanState::ChoosePhysicalDeviceStrategy{ChooseFirstSupportedStrategy{}};
+    VulkanState vulkan{ws.vulkan_wsi(), device_strategy}; 
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,8 +115,8 @@ try
 
     auto& ws = ws_loader.load_window_system();
 
-    auto vulkan = options.use_device_with_index.second ?
-        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_index.first}} :
+    auto vulkan = options.use_device_with_uuid.second ?
+        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_uuid.first}} :
         VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,8 +113,20 @@ try
         return 0;
     }
 
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosed_strategy;
+    if (options.use_device_with_index.second)
+        choosed_strategy = std::make_unique<ChooseIndexPhysicalDevice>(options.use_device_with_index.first);
+    else
+        choosed_strategy = std::make_unique<ChooseFirstSupportedPhysicalDevice>();
+
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choosed_strategy.get()};
+
+    if (options.list_devices)
+    {
+        log_info(vulkan.instance().enumeratePhysicalDevices());
+        return 0;
+    }
 
     auto const ws_vulkan_deinit = Util::on_scope_exit([&] { ws.deinit_vulkan(); });
     ws.init_vulkan(vulkan);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ try
     auto& ws = ws_loader.load_window_system();
 
     auto vulkan = options.use_device_with_index.second ?
-        VulkanState{ws.vulkan_wsi(), ChooseByIndexStrategy{options.use_device_with_index.first}} :
+        VulkanState{ws.vulkan_wsi(), ChooseByUUIDStrategy{options.use_device_with_index.first}} :
         VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,7 +122,7 @@ try
 
     if (options.list_devices)
     {
-        log_info(vulkan.instance().enumeratePhysicalDevices());
+        vulkan.log_all_devices();
         return 0;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,14 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosen_strategy;
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choose_physical_device_strategy;
     if (options.use_device_with_index.second)
-        choosen_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
+        choose_physical_device_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
     else
-        choosen_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
+        choose_physical_device_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
 
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choosen_strategy.get()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choose_physical_device_strategy.get()};
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,11 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choose_physical_device_strategy;
-    if (options.use_device_with_index.second)
-        choose_physical_device_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
-    else
-        choose_physical_device_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
-
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choose_physical_device_strategy.get()};
+
+    auto vulkan = options.use_device_with_index.second ?
+        VulkanState{ws.vulkan_wsi(), ChooseByIndexStrategy{options.use_device_with_index.first}} :
+        VulkanState{ws.vulkan_wsi(), ChooseFirstSupportedStrategy{}};
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,14 +113,14 @@ try
         return 0;
     }
 
-    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosed_strategy;
+    std::unique_ptr<ChoosePhysicalDeviceStrategy> choosen_strategy;
     if (options.use_device_with_index.second)
-        choosed_strategy = std::make_unique<ChooseIndexPhysicalDevice>(options.use_device_with_index.first);
+        choosen_strategy = std::make_unique<ChooseByIndexStrategy>(options.use_device_with_index.first);
     else
-        choosed_strategy = std::make_unique<ChooseFirstSupportedPhysicalDevice>();
+        choosen_strategy = std::make_unique<ChooseFirstSupportedStrategy>();
 
     auto& ws = ws_loader.load_window_system();
-    VulkanState vulkan{ws.vulkan_wsi(), *choosed_strategy.get()};
+    VulkanState vulkan{ws.vulkan_wsi(), *choosen_strategy.get()};
 
     if (options.list_devices)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "window_system.h"
 #include "window_system_loader.h"
 #include "vulkan_state.h"
+#include "device_uuid.h"
 #include "scene.h"
 #include "scene_collection.h"
 #include "benchmark_collection.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ core_sources = files(
     'benchmark.cpp',
     'benchmark_collection.cpp',
     'default_benchmarks.cpp',
+    'device_uuid.cpp',
     'log.cpp',
     'main_loop.cpp',
     'mesh.cpp',

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -166,7 +166,7 @@ std::string Options::help_string()
         "      --run-forever           Run indefinitely, looping from the last benchmark\n"
         "                              back to the first\n"
         "  -d, --debug                 Display debug messages\n"
-        "  -D  --use-device            Use Vulkan device with index as in list\n"
+        "  -D  --use-device            Use Vulkan device with specified UUID\n"
         "  -L  --list-devices          List Vulkan devices\n"
         "  -h, --help                  Display help\n";
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -20,10 +20,15 @@
  *   Alexandros Frantzis <alexandros.frantzis@collabora.com>
  */
 
+#include <array>
+#include <bits/getopt_core.h>
 #include <cstdio>
+#include <cstring>
 #include <getopt.h>
 #include <algorithm>
 #include <cctype>
+#include <string>
+#include <vulkan/vulkan_core.h>
 
 #include "options.h"
 #include "util.h"
@@ -137,7 +142,7 @@ Options::Options()
       show_debug{false},
       show_help{false},
       list_devices{false},
-      use_device_with_index{}
+      use_device_with_uuid{}
 {
 }
 
@@ -228,7 +233,16 @@ bool Options::parse_args(int argc, char **argv)
         else if (c == 'L' || optname == "list-devices")
             list_devices = true;
         else if (c == 'D' || optname == "use-device")
-            use_device_with_index = std::make_pair(static_cast<uint32_t>(std::stoi(optarg)), true);
+        {
+            std::string formated_argument{optarg};
+            formated_argument.resize(2 * VK_UUID_SIZE + 1);
+            formated_argument.back() = '\0';
+            
+            std::array<char, 2 * VK_UUID_SIZE + 1> representation;
+            std::copy(formated_argument.cbegin(), formated_argument.cend(), representation.begin());
+
+            use_device_with_uuid = std::make_pair(encode_UUID<VK_UUID_SIZE>(representation), true);
+        }
     }
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,6 +36,7 @@ namespace
 struct option long_options[] = {
     {"benchmark", 1, 0, 0},
     {"size", 1, 0, 0},
+    {"force-device", 1, 0, 0},
     {"fullscreen", 0, 0, 0},
     {"present-mode", 1, 0, 0},
     {"pixel-format", 1, 0, 0},
@@ -133,7 +134,9 @@ Options::Options()
       data_dir{VKMARK_DATA_DIR},
       run_forever{false},
       show_debug{false},
-      show_help{false}
+      show_help{false},
+      list_devices{false},
+      use_device_with_index{}
 {
 }
 
@@ -162,6 +165,8 @@ std::string Options::help_string()
         "      --run-forever           Run indefinitely, looping from the last benchmark\n"
         "                              back to the first\n"
         "  -d, --debug                 Display debug messages\n"
+        "  -D  --use-device            Use Vulkan device with index as in list\n"
+        "  -L  --list-devices          List Vulkan devices\n"
         "  -h, --help                  Display help\n";
 
     for (auto const& wsh : window_system_help)
@@ -181,7 +186,7 @@ bool Options::parse_args(int argc, char **argv)
         int c;
         std::string optname;
 
-        c = getopt_long(argc, argv, "b:s:p:ldh",
+        c = getopt_long(argc, argv, "b:s:p:ldhD:L",
                         long_options, &option_index);
         if (c == -1)
             break;
@@ -219,6 +224,10 @@ bool Options::parse_args(int argc, char **argv)
             show_debug = true;
         else if (c == 'h' || optname == "help")
             show_help = true;
+        else if (c == 'L' || optname == "list-devices")
+            list_devices = true;
+        else if (c == 'D' || optname == "use-device")
+            use_device_with_index = std::make_pair(static_cast<uint32_t>(std::stoi(optarg)), true);
     }
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -46,6 +46,7 @@ struct option long_options[] = {
     {"data-dir", 1, 0, 0},
     {"winsys", 1, 0, 0},
     {"winsys-options", 1, 0, 0},
+    {"list-devices", 0, 0, 0},
     {"run-forever", 0, 0, 0},
     {"debug", 0, 0, 0},
     {"help", 0, 0, 0},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -20,16 +20,13 @@
  *   Alexandros Frantzis <alexandros.frantzis@collabora.com>
  */
 
-#include <array>
-#include <bits/getopt_core.h>
+
 #include <cstdio>
-#include <cstring>
 #include <getopt.h>
 #include <algorithm>
 #include <cctype>
 #include <string>
 #include <utility>
-#include <vulkan/vulkan_core.h>
 
 #include "options.h"
 #include "util.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cctype>
 #include <string>
+#include <utility>
 #include <vulkan/vulkan_core.h>
 
 #include "options.h"
@@ -234,14 +235,8 @@ bool Options::parse_args(int argc, char **argv)
             list_devices = true;
         else if (c == 'D' || optname == "use-device")
         {
-            std::string formated_argument{optarg};
-            formated_argument.resize(2 * VK_UUID_SIZE + 1);
-            formated_argument.back() = '\0';
-            
-            std::array<char, 2 * VK_UUID_SIZE + 1> representation;
-            std::copy(formated_argument.cbegin(), formated_argument.cend(), representation.begin());
-
-            use_device_with_uuid = std::make_pair(encode_UUID<VK_UUID_SIZE>(representation), true);
+            DeviceUUID&& uuid{std::string {optarg}};
+            use_device_with_uuid = std::make_pair(uuid, true);
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,7 +36,7 @@ namespace
 struct option long_options[] = {
     {"benchmark", 1, 0, 0},
     {"size", 1, 0, 0},
-    {"force-device", 1, 0, 0},
+    {"use-device", 1, 0, 0},
     {"fullscreen", 0, 0, 0},
     {"present-mode", 1, 0, 0},
     {"pixel-format", 1, 0, 0},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -232,8 +232,7 @@ bool Options::parse_args(int argc, char **argv)
             list_devices = true;
         else if (c == 'D' || optname == "use-device")
         {
-            DeviceUUID&& uuid{std::string {optarg}};
-            use_device_with_uuid = std::make_pair(uuid, true);
+            use_device_with_uuid = std::make_pair(DeviceUUID{std::string {optarg}}, true);
         }
     }
 

--- a/src/options.h
+++ b/src/options.h
@@ -55,6 +55,8 @@ struct Options
     bool run_forever;
     bool show_debug;
     bool show_help;
+    bool list_devices;
+    std::pair<uint32_t, bool> use_device_with_index; // pseudo-optional
 
 private:
     std::vector<std::string> window_system_help;

--- a/src/options.h
+++ b/src/options.h
@@ -28,6 +28,8 @@
 
 #include <vulkan/vulkan.hpp>
 
+#include "device_uuid.h"
+
 struct Options
 {
     struct WindowSystemOption
@@ -56,7 +58,7 @@ struct Options
     bool show_debug;
     bool show_help;
     bool list_devices;
-    std::pair<uint32_t, bool> use_device_with_index; // pseudo-optional
+    std::pair<DeviceUUID, bool> use_device_with_uuid; // pseudo-optional
 
 private:
     std::vector<std::string> window_system_help;

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -21,7 +21,9 @@
  */
 
 #include "vulkan_state.h"
+#include "device_uuid.h"
 #include "log.h"
+#include <string>
 
 
 void log_info(vk::PhysicalDevice const& physical_device)
@@ -32,7 +34,8 @@ void log_info(vk::PhysicalDevice const& physical_device)
     Log::info("    Device ID:      0x%X\n", props.deviceID);
     Log::info("    Device Name:    %s\n", props.deviceName.data());
     Log::info("    Driver Version: %u\n", props.driverVersion);
-    Log::info("    Device UUID:    %s\n", decode_UUID(props.pipelineCacheUUID).data());
+    Log::info("    Device UUID:    %s\n", 
+        static_cast<std::string>(static_cast<DeviceUUID>(props.pipelineCacheUUID)).c_str());
 }
 
 void log_info(std::vector<vk::PhysicalDevice> const& physical_devices)
@@ -160,7 +163,9 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(std::vector<vk::Phys
         }
 
         Log::debug("device with uuid %s skipped!\n",
-            decode_UUID(physical_device.getProperties().pipelineCacheUUID).data());
+           static_cast<std::string>(
+               static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID)).c_str()
+            );
     }
     
     throw std::runtime_error("No suitable Vulkan physical devices found");
@@ -168,11 +173,12 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(std::vector<vk::Phys
 
 vk::PhysicalDevice ChooseByUUIDStrategy::operator()(std::vector<vk::PhysicalDevice> avaiable_devices)
 {
-    Log::debug("Trying to use device with specified UUID %s.\n", decode_UUID(m_selected_device_uuid).data());
+    Log::debug("Trying to use device with specified UUID %s.\n", 
+        static_cast<std::string>(m_selected_device_uuid).c_str());
 
     for (auto const& physical_device: avaiable_devices)
     {
-        if (physical_device.getProperties().pipelineCacheUUID == m_selected_device_uuid)
+        if (static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID) == m_selected_device_uuid)
         {
             Log::debug("Device found\n");
             return physical_device;

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -181,9 +181,6 @@ void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWS
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 
-    // TODO: move to print list of physical devices
-    // Log::debug("Found %d physical devices\n", physical_devices.size());
-
     Log::debug("Trying to use device with specified index %d.\n", use_physical_device_index);
 
     if (use_physical_device_index < physical_devices.size())

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -31,15 +31,15 @@
 std::vector<vk::PhysicalDevice> VulkanState::avaiable_devices(VulkanWSI& vulkan_wsi)
 {
     auto avaiable_devices = instance().enumeratePhysicalDevices();
-        for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
+    for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
+    {
+        if (!vulkan_wsi.is_physical_device_supported(*it_device))
         {
-            if (!vulkan_wsi.is_physical_device_supported(*it_device))
-            {
-                avaiable_devices.erase(it_device);
-                Log::debug("device with uuid %s is not supported by window system integration layer", 
-                    static_cast<DeviceUUID>(it_device->getProperties().pipelineCacheUUID).representation().data());
-            }
+            avaiable_devices.erase(it_device);
+            Log::debug("device with uuid %s is not supported by window system integration layer", 
+                static_cast<DeviceUUID>(it_device->getProperties().pipelineCacheUUID).representation().data());
         }
+    }
 
     return avaiable_devices;
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -22,7 +22,6 @@
 
 #include "vulkan_state.h"
 #include "device_uuid.h"
-#include "log.h"
 
 #include <array>
 
@@ -184,5 +183,5 @@ vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::Physic
         }
     }
 
-    throw std::runtime_error(std::string("Could not find device by UUID!"));
+    throw std::runtime_error(std::string("Device specified by uuid is not avaiable!"));
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -150,7 +150,7 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(std::vector<vk::PhysicalDevice> avaiable_devices)
+vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices)
 {
     Log::debug("Trying to use first supported device.\n");
 
@@ -171,7 +171,7 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(std::vector<vk::Phys
     throw std::runtime_error("No suitable Vulkan physical devices found");
 }
 
-vk::PhysicalDevice ChooseByUUIDStrategy::operator()(std::vector<vk::PhysicalDevice> avaiable_devices)
+vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices)
 {
     Log::debug("Trying to use device with specified UUID %s.\n", 
         static_cast<std::string>(m_selected_device_uuid).c_str());

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -28,20 +28,20 @@
 #include <array>
 #include <vector>
 
-std::vector<vk::PhysicalDevice> VulkanState::avaiable_devices(VulkanWSI& vulkan_wsi)
+std::vector<vk::PhysicalDevice> VulkanState::available_devices(VulkanWSI& vulkan_wsi)
 {
-    auto avaiable_devices = instance().enumeratePhysicalDevices();
-    for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
+    auto available_devices = instance().enumeratePhysicalDevices();
+    for (auto it_device = available_devices.begin(); it_device < available_devices.end(); ++it_device)
     {
         if (!vulkan_wsi.is_physical_device_supported(*it_device))
         {
-            avaiable_devices.erase(it_device);
+            available_devices.erase(it_device);
             Log::debug("device with uuid %s is not supported by window system integration layer", 
                 static_cast<DeviceUUID>(it_device->getProperties().pipelineCacheUUID).representation().data());
         }
     }
 
-    return avaiable_devices;
+    return available_devices;
 }
 
 void log_info(vk::PhysicalDevice const& physical_device)
@@ -167,11 +167,11 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices)
+vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk::PhysicalDevice>& available_devices)
 {
     Log::debug("Trying to use first supported device.\n");
 
-    for (auto const& physical_device : avaiable_devices)
+    for (auto const& physical_device : available_devices)
     {
         if (find_queue_family_index(physical_device, vk::QueueFlagBits::eGraphics).second)
         {
@@ -187,12 +187,12 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk
     throw std::runtime_error("No suitable Vulkan physical devices found");
 }
 
-vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices)
+vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::PhysicalDevice>& available_devices)
 {
     Log::debug("Trying to use device with specified UUID %s.\n", 
         m_selected_device_uuid.representation().data());
 
-    for (auto const& physical_device: avaiable_devices)
+    for (auto const& physical_device: available_devices)
     {
         if (static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID) == m_selected_device_uuid)
         {
@@ -201,5 +201,5 @@ vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::Physic
         }
     }
 
-    throw std::runtime_error(std::string("Device specified by uuid is not avaiable!"));
+    throw std::runtime_error(std::string("Device specified by uuid is not available!"));
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -44,6 +44,13 @@ std::pair<uint32_t, bool> find_queue_family_index(vk::PhysicalDevice pd, vk::Que
     return std::make_pair(0, false);
 }
 
+VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
+{
+    create_instance(vulkan_wsi);
+    create_physical_device(vulkan_wsi, pd_strategy);
+    create_logical_device(vulkan_wsi);
+    create_command_pool();
+}
 
 std::vector<vk::PhysicalDevice> VulkanState::available_devices(VulkanWSI& vulkan_wsi)
 {

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -22,9 +22,27 @@
 
 #include "vulkan_state.h"
 #include "device_uuid.h"
+#include "vulkan_wsi.h"
+#include "log.h"
 
 #include <array>
+#include <vector>
 
+std::vector<vk::PhysicalDevice> VulkanState::avaiable_devices(VulkanWSI& vulkan_wsi)
+{
+    auto avaiable_devices = instance().enumeratePhysicalDevices();
+        for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
+        {
+            if (!vulkan_wsi.is_physical_device_supported(*it_device))
+            {
+                avaiable_devices.erase(it_device);
+                Log::debug("device with uuid %s is not supported by window system integration layer", 
+                    static_cast<DeviceUUID>(it_device->getProperties().pipelineCacheUUID).representation().data());
+            }
+        }
+
+    return avaiable_devices;
+}
 
 void log_info(vk::PhysicalDevice const& physical_device)
 {

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -40,14 +40,16 @@ VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy con
 std::vector<vk::PhysicalDevice> VulkanState::available_devices(VulkanWSI& vulkan_wsi) const
 {
     auto available_devices = instance().enumeratePhysicalDevices();
-    for (auto it_device = available_devices.begin(); it_device < available_devices.end(); ++it_device)
+    for (auto it_device = available_devices.begin(); it_device != available_devices.end();)
     {
         if (!vulkan_wsi.is_physical_device_supported(*it_device))
         {
-            available_devices.erase(it_device);
             Log::debug("device with uuid %s is not supported by window system integration layer", 
                 static_cast<DeviceUUID>(it_device->getProperties().pipelineCacheUUID).representation().data());
+            it_device = available_devices.erase(it_device);
         }
+        else
+            ++it_device;
     }
 
     return available_devices;

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -215,9 +215,7 @@ void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& v
         Log::warning("Device with index %d does not exist!\n", physical_device_index);
 
     if(!vk_physical_device)
-    {
        throw std::runtime_error("Could not use device with index " + std::to_string(physical_device_index) + "!\n");
-    }
 
     Log::debug("Device with index %d succesfully choosen!\n", physical_device_index);
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -53,7 +53,7 @@ std::vector<vk::PhysicalDevice> VulkanState::available_devices(VulkanWSI& vulkan
     return available_devices;
 }
 
-void log_device_info(vk::PhysicalDevice const& device)
+static void log_device_info(vk::PhysicalDevice const& device)
 {
     auto const props = device.getProperties();
 

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -141,7 +141,7 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-void ChooseFirstSupportedPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     Log::debug("Trying to use first supported device.\n");
 
@@ -177,15 +177,15 @@ void ChooseFirstSupportedPhysicalDevice::choose(vk::Instance const& vk_instance,
     Log::debug("First supported device choosen!\n");
 }
 
-void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 
-    Log::debug("Trying to use device with specified index %d.\n", use_physical_device_index);
+    Log::debug("Trying to use device with specified index %d.\n", physical_device_index);
 
-    if (use_physical_device_index < physical_devices.size())
+    if (physical_device_index < physical_devices.size())
     {
-        auto const pd = physical_devices[use_physical_device_index];
+        auto const pd = physical_devices[physical_device_index];
 
         if (vulkan_wsi.is_physical_device_supported(pd))
         {
@@ -212,12 +212,12 @@ void ChooseIndexPhysicalDevice::choose(vk::Instance const& vk_instance, VulkanWS
         
     }
     else
-        Log::warning("Device with index %d does not exist!\n", use_physical_device_index);
+        Log::warning("Device with index %d does not exist!\n", physical_device_index);
 
     if(!vk_physical_device)
     {
-       throw std::runtime_error("Could not use device with index " + std::to_string(use_physical_device_index) + "!\n");
+       throw std::runtime_error("Could not use device with index " + std::to_string(physical_device_index) + "!\n");
     }
 
-    Log::debug("Device with index %d succesfully choosen!\n", use_physical_device_index);
+    Log::debug("Device with index %d succesfully choosen!\n", physical_device_index);
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -23,7 +23,8 @@
 #include "vulkan_state.h"
 #include "device_uuid.h"
 #include "log.h"
-#include <string>
+
+#include <array>
 
 
 void log_info(vk::PhysicalDevice const& physical_device)
@@ -32,10 +33,9 @@ void log_info(vk::PhysicalDevice const& physical_device)
 
     Log::info("    Vendor ID:      0x%X\n", props.vendorID);
     Log::info("    Device ID:      0x%X\n", props.deviceID);
-    Log::info("    Device Name:    %s\n", props.deviceName.data());
+    Log::info("    Device Name:    %s\n", static_cast<char const*>(props.deviceName));
     Log::info("    Driver Version: %u\n", props.driverVersion);
-    Log::info("    Device UUID:    %s\n", 
-        static_cast<std::string>(static_cast<DeviceUUID>(props.pipelineCacheUUID)).c_str());
+    Log::info("    Device UUID:    %s\n", static_cast<DeviceUUID>(props.pipelineCacheUUID).representation().data());
 }
 
 void log_info(std::vector<vk::PhysicalDevice> const& physical_devices)
@@ -163,9 +163,8 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk
         }
 
         Log::debug("device with uuid %s skipped!\n",
-           static_cast<std::string>(
-               static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID)).c_str()
-            );
+               static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID).representation().data()
+        );
     }
     
     throw std::runtime_error("No suitable Vulkan physical devices found");
@@ -174,7 +173,7 @@ vk::PhysicalDevice ChooseFirstSupportedStrategy::operator()(const std::vector<vk
 vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices)
 {
     Log::debug("Trying to use device with specified UUID %s.\n", 
-        static_cast<std::string>(m_selected_device_uuid).c_str());
+        m_selected_device_uuid.representation().data());
 
     for (auto const& physical_device: avaiable_devices)
     {

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -47,18 +47,6 @@ void log_info(std::vector<vk::PhysicalDevice> const& physical_devices)
     }
 }
 
-VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy& choose_physical_device_strategy)
-{
-    create_instance(vulkan_wsi);
-
-    choose_physical_device_strategy.choose(instance(), vulkan_wsi);
-    vk_physical_device = choose_physical_device_strategy.physical_device();
-    vk_graphics_queue_family_index = choose_physical_device_strategy.graphics_queue_family_index();
-
-    create_device(vulkan_wsi);
-    create_command_pool();
-}
-
 void VulkanState::create_instance(VulkanWSI& vulkan_wsi)
 {
     auto const app_info = vk::ApplicationInfo{}
@@ -141,7 +129,7 @@ void VulkanState::create_command_pool()
         [this] (auto& cp) { this->device().destroyCommandPool(cp); }};
 }
 
-void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseFirstSupportedStrategy::operator()(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     Log::debug("Trying to use first supported device.\n");
 
@@ -177,7 +165,7 @@ void ChooseFirstSupportedStrategy::choose(vk::Instance const& vk_instance, Vulka
     Log::debug("First supported device choosen!\n");
 }
 
-void ChooseByIndexStrategy::choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
+void ChooseByIndexStrategy::operator()(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi)
 {
     auto const physical_devices = vk_instance.enumeratePhysicalDevices();
 

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -106,6 +106,11 @@ void VulkanState::create_instance(VulkanWSI& vulkan_wsi)
         [] (auto& i) { i.destroy(); }};
 }
 
+void VulkanState::create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
+{
+    vk_physical_device = pd_strategy(available_devices(vulkan_wsi));
+}
+
 void VulkanState::create_logical_device(VulkanWSI& vulkan_wsi)
 {
     // it would be really nice to support c++17

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -104,7 +104,7 @@ void VulkanState::create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDe
 }
 
 // pseudo-optional
-std::pair<uint32_t, bool> find_queue_family_index(vk::PhysicalDevice pd, vk::QueueFlagBits queue_family_type)
+static std::pair<uint32_t, bool> find_queue_family_index(vk::PhysicalDevice pd, vk::QueueFlagBits queue_family_type)
 {
     auto const queue_families = pd.getQueueFamilyProperties();
     

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -180,10 +180,10 @@ vk::PhysicalDevice ChooseByUUIDStrategy::operator()(const std::vector<vk::Physic
     {
         if (static_cast<DeviceUUID>(physical_device.getProperties().pipelineCacheUUID) == m_selected_device_uuid)
         {
-            Log::debug("Device found\n");
+            Log::debug("Device found by UUID\n");
             return physical_device;
         }
     }
 
-    throw std::runtime_error(std::string("Could not find!"));
+    throw std::runtime_error(std::string("Could not find device by UUID!"));
 }

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -26,7 +26,6 @@
 
 #include "managed_resource.h"
 #include "vulkan_wsi.h"
-#include "log.h"
 
 
 void log_info(vk::PhysicalDevice const& physical_device);
@@ -47,17 +46,7 @@ public:
     template<typename ChoosePhysicalDeviceStrategy>
     void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy pd_strategy)
     {
-        auto avaiable_devices = instance().enumeratePhysicalDevices();
-        for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
-        {
-            if (!vulkan_wsi.is_physical_device_supported(*it_device))
-            {
-                avaiable_devices.erase(it_device);
-                Log::debug("device wit uuid %s ins not supported by window system integration layer");
-            }
-        }
-
-        vk_physical_device = pd_strategy(avaiable_devices);
+        vk_physical_device = pd_strategy(avaiable_devices(vulkan_wsi));
     }
 
     void log_info()
@@ -100,6 +89,7 @@ private:
     void choose_physical_device(VulkanWSI& vulkan_wsi);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
+    std::vector<vk::PhysicalDevice> avaiable_devices(VulkanWSI& vulkan_wsi);
 
     ManagedResource<vk::Instance> vk_instance;
     ManagedResource<vk::Device> vk_device;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -26,6 +26,7 @@
 
 #include "managed_resource.h"
 #include "vulkan_wsi.h"
+#include "log.h"
 
 
 void log_info(vk::PhysicalDevice const& physical_device);
@@ -50,7 +51,10 @@ public:
         for (auto it_device = avaiable_devices.begin(); it_device < avaiable_devices.end(); ++it_device)
         {
             if (!vulkan_wsi.is_physical_device_supported(*it_device))
+            {
                 avaiable_devices.erase(it_device);
+                Log::debug("device wit uuid %s ins not supported by window system integration layer");
+            }
         }
 
         vk_physical_device = pd_strategy(avaiable_devices);

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -46,7 +46,7 @@ public:
     template<typename ChoosePhysicalDeviceStrategy>
     void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy pd_strategy)
     {
-        vk_physical_device = pd_strategy(avaiable_devices(vulkan_wsi));
+        vk_physical_device = pd_strategy(available_devices(vulkan_wsi));
     }
 
     void log_info()
@@ -89,7 +89,7 @@ private:
     void choose_physical_device(VulkanWSI& vulkan_wsi);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
-    std::vector<vk::PhysicalDevice> avaiable_devices(VulkanWSI& vulkan_wsi);
+    std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi);
 
     ManagedResource<vk::Instance> vk_instance;
     ManagedResource<vk::Device> vk_device;
@@ -106,7 +106,7 @@ private:
 class ChooseFirstSupportedStrategy
 {
 public:
-    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices);
+    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& available_devices);
 };
 
 class ChooseByUUIDStrategy
@@ -116,7 +116,7 @@ public:
         : m_selected_device_uuid(uuid)
     {}
 
-    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices);
+    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& available_devices);
 
 private:
     DeviceUUID m_selected_device_uuid;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -34,7 +34,7 @@ class VulkanState
 {
 public:
     template <typename ChoosePhysicalDeviceStrategy>
-    inline VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy choose_physical_device_strategy)
+    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy choose_physical_device_strategy)
     {
         create_instance(vulkan_wsi);
 
@@ -46,7 +46,7 @@ public:
         create_command_pool();
     }
 
-    inline void log_info()
+    void log_info()
     {
         ::log_info(physical_device());
     }
@@ -102,12 +102,12 @@ class ChooseFirstSupportedStrategy
 public:
     ~ChooseFirstSupportedStrategy(){};
 
-    inline vk::PhysicalDevice const& physical_device() const noexcept
+    vk::PhysicalDevice const& physical_device() const noexcept
     {
         return vk_physical_device;
     }
 
-    inline uint32_t const& graphics_queue_family_index() const noexcept
+    uint32_t const& graphics_queue_family_index() const noexcept
     {
         return vk_graphics_queue_family_index;
     }
@@ -122,7 +122,7 @@ public:
 class ChooseByIndexStrategy : public ChooseFirstSupportedStrategy
 {
 public:
-    inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
+    ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
         : physical_device_index(use_physical_device_with_index)
     {}
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -24,14 +24,13 @@
 
 #include <vulkan/vulkan.hpp>
 
-#include "vulkan_wsi.h"
 #include "managed_resource.h"
 #include "device_uuid.h"
+#include "vulkan_wsi.h"
 
-class VulkanWSI;
+
 void log_info(vk::PhysicalDevice const& physical_device);
 void log_info(std::vector<vk::PhysicalDevice> const& physical_devices);
-
 
 class VulkanState
 {
@@ -112,7 +111,7 @@ private:
 class ChooseFirstSupportedStrategy
 {
 public:
-    vk::PhysicalDevice operator()(std::vector<vk::PhysicalDevice> avaiable_devices);
+    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices);
 };
 
 class ChooseByUUIDStrategy
@@ -122,7 +121,7 @@ public:
         : m_selected_device_uuid(uuid)
     {}
 
-    vk::PhysicalDevice operator()(std::vector<vk::PhysicalDevice> avaiable_devices);
+    vk::PhysicalDevice operator()(const std::vector<vk::PhysicalDevice>& avaiable_devices);
 
 private:
     DeviceUUID m_selected_device_uuid;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -32,9 +32,10 @@
 class VulkanState
 {
 public:
+    using ChoosePhysicalDeviceStrategy = 
+        std::function<vk::PhysicalDevice (std::vector<vk::PhysicalDevice> const&)>;
     
-    template<typename ChoosePhysicalDeviceStrategy>
-    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy pd_strategy)
+    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
     {
         create_instance(vulkan_wsi);
         create_physical_device(vulkan_wsi, pd_strategy);
@@ -42,8 +43,7 @@ public:
         create_command_pool();
     }
 
-    template<typename ChoosePhysicalDeviceStrategy>
-    void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy pd_strategy)
+    void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
     {
         vk_physical_device = pd_strategy(available_devices(vulkan_wsi));
     }
@@ -110,7 +110,6 @@ private:
 
 #include "device_uuid.h"
 
-// template strategies seems to require simpler code than polymorphic
 class ChooseFirstSupportedStrategy
 {
 public:

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
-#include <optional>
 
 #include "managed_resource.h"
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -25,7 +25,6 @@
 #include <vulkan/vulkan.hpp>
 
 #include "managed_resource.h"
-#include "device_uuid.h"
 #include "vulkan_wsi.h"
 
 
@@ -106,6 +105,8 @@ private:
     uint32_t vk_graphics_queue_family_index;
     
 };
+
+#include "device_uuid.h"
 
 // template strategies seems to require simpler code than polymorphic
 class ChooseFirstSupportedStrategy

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -118,9 +118,8 @@ class ChooseByIndexStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
     inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
-    {
-        physical_device_index = use_physical_device_with_index;
-    }
+        : physical_device_index(use_physical_device_with_index)
+    {}
 
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -28,9 +28,6 @@
 #include "vulkan_wsi.h"
 
 
-void log_info(vk::PhysicalDevice const& physical_device);
-void log_info(std::vector<vk::PhysicalDevice> const& physical_devices);
-
 class VulkanState
 {
 public:
@@ -51,7 +48,7 @@ public:
 
     void log_info()
     {
-        ::log_info(physical_device());
+        log_info(physical_device());
     }
 
     vk::Instance const& instance() const
@@ -84,11 +81,14 @@ public:
         return vk_command_pool;
     }
 
+    void log_all_devices();
+
 private:
     void create_instance(VulkanWSI& vulkan_wsi);
     void choose_physical_device(VulkanWSI& vulkan_wsi);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
+    void log_info(vk::PhysicalDevice const& device);
     std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi);
 
     ManagedResource<vk::Instance> vk_instance;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -79,9 +79,8 @@ private:
 
     ManagedResource<vk::Instance> vk_instance;
     ManagedResource<vk::Device> vk_device;
-    vk::Queue vk_graphics_queue;
     ManagedResource<vk::CommandPool> vk_command_pool;
-    std::pair<size_t, bool> force_physical_device; // pseudo-optional
+    vk::Queue vk_graphics_queue;
     vk::PhysicalDevice vk_physical_device;
     uint32_t vk_graphics_queue_family_index;
     

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -37,17 +37,6 @@ public:
     
     VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
 
-    void log_info()
-    {
-        log_info(physical_device());
-    }
-
-    void log_all_devices()
-    {
-        // all devices not devices supported by wsi
-        log_all_devices(instance().enumeratePhysicalDevices());
-    }
-
     vk::Instance const& instance() const
     {
         return vk_instance;
@@ -78,17 +67,16 @@ public:
         return vk_command_pool;
     }
 
+    void log_info() const;
+    void log_all_devices() const;
 
 private:
 
-
-    void log_info(vk::PhysicalDevice const& device);
-    void log_all_devices(std::vector<vk::PhysicalDevice> const& physical_devices);
     void create_instance(VulkanWSI& vulkan_wsi);
     void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
-    std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi);
+    std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi) const;
 
     ManagedResource<vk::Instance> vk_instance;
     ManagedResource<vk::Device> vk_device;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -110,22 +110,22 @@ protected:
     uint32_t vk_graphics_queue_family_index;
 };
 
-class ChooseFirstSupportedPhysicalDevice : public ChoosePhysicalDeviceStrategy
+class ChooseFirstSupportedStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 };
 
-class ChooseIndexPhysicalDevice : public ChoosePhysicalDeviceStrategy
+class ChooseByIndexStrategy : public ChoosePhysicalDeviceStrategy
 {
 public:
-    inline ChooseIndexPhysicalDevice(uint32_t use_physical_device_index)
+    inline ChooseByIndexStrategy(uint32_t use_physical_device_with_index)
     {
-        this->use_physical_device_index = use_physical_device_index;
+        physical_device_index = use_physical_device_with_index;
     }
 
     void choose(vk::Instance const& vk_instance, VulkanWSI& vulkan_wsi) override;
 
 private:
-    uint32_t use_physical_device_index;
+    uint32_t physical_device_index;
 };

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -36,11 +36,6 @@ public:
         std::function<vk::PhysicalDevice (std::vector<vk::PhysicalDevice> const&)>;
     
     VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
-    
-    void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
-    {
-        vk_physical_device = pd_strategy(available_devices(vulkan_wsi));
-    }
 
     void log_info()
     {
@@ -84,11 +79,13 @@ public:
     }
 
 
-private: 
+private:
+
+
     void log_info(vk::PhysicalDevice const& device);
     void log_all_devices(std::vector<vk::PhysicalDevice> const& physical_devices);
     void create_instance(VulkanWSI& vulkan_wsi);
-    void choose_physical_device(VulkanWSI& vulkan_wsi);
+    void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
     std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi);

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -26,6 +26,7 @@
 
 #include "vulkan_wsi.h"
 #include "managed_resource.h"
+#include "device_uuid.h"
 
 class VulkanWSI;
 void log_info(vk::PhysicalDevice const& physical_device);
@@ -117,12 +118,12 @@ public:
 class ChooseByUUIDStrategy
 {
 public:
-    ChooseByUUIDStrategy(uint32_t use_physical_device_with_index)
-        : m_selected_device_index(use_physical_device_with_index)
+    ChooseByUUIDStrategy(const DeviceUUID& uuid)
+        : m_selected_device_uuid(uuid)
     {}
 
     vk::PhysicalDevice operator()(std::vector<vk::PhysicalDevice> avaiable_devices);
 
 private:
-    uint32_t m_selected_device_index;
+    DeviceUUID m_selected_device_uuid;
 };

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <functional>
 #include <vulkan/vulkan.hpp>
 
 #include "managed_resource.h"
@@ -31,6 +32,7 @@
 class VulkanState
 {
 public:
+    
     template<typename ChoosePhysicalDeviceStrategy>
     VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy pd_strategy)
     {
@@ -49,6 +51,12 @@ public:
     void log_info()
     {
         log_info(physical_device());
+    }
+
+    void log_all_devices()
+    {
+        // all devices not devices supported by wsi
+        log_all_devices(instance().enumeratePhysicalDevices());
     }
 
     vk::Instance const& instance() const
@@ -81,14 +89,14 @@ public:
         return vk_command_pool;
     }
 
-    void log_all_devices();
 
-private:
+private: 
+    void log_info(vk::PhysicalDevice const& device);
+    void log_all_devices(std::vector<vk::PhysicalDevice> const& physical_devices);
     void create_instance(VulkanWSI& vulkan_wsi);
     void choose_physical_device(VulkanWSI& vulkan_wsi);
     void create_logical_device(VulkanWSI& vulkan_wsi);
     void create_command_pool();
-    void log_info(vk::PhysicalDevice const& device);
     std::vector<vk::PhysicalDevice> available_devices(VulkanWSI& vulkan_wsi);
 
     ManagedResource<vk::Instance> vk_instance;

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -35,14 +35,8 @@ public:
     using ChoosePhysicalDeviceStrategy = 
         std::function<vk::PhysicalDevice (std::vector<vk::PhysicalDevice> const&)>;
     
-    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
-    {
-        create_instance(vulkan_wsi);
-        create_physical_device(vulkan_wsi, pd_strategy);
-        create_logical_device(vulkan_wsi);
-        create_command_pool();
-    }
-
+    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
+    
     void create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
     {
         vk_physical_device = pd_strategy(available_devices(vulkan_wsi));


### PR DESCRIPTION
Hi

In my computer I have multiple GPUs. Vulkan requires explicit selection which gpu to use for what. Before VulkanState was choosing first avaiable gpu (which in my case was integrated gpu, I wanted to test them both but i needed mostly to test the dedicated gpu which i thought was underperforming (which was true then ...) - and it was impossible without changing the code).

I moved responsibility of choosing GPU from VulkanState to specialised strategy classes and wrote some functionality to explicitly select GPU to use. 
I also used vulkan device UUID this time to be usefull for those folks with two or more identical graphics cards. It is unique for each physical gpu on the machine instead of the index in array they appear in enumeratePhysicalDevices which does not have to be the same across every program.

The old behaviour is preserved for legacy uses. You can choose device by using new arguments and only then new behaviour takes place.

This should close #10 and probably #2 (As far as i know DRI_PRIME is for Mesa/OpenGL applications only)

Here is how it works:

```
# old behaviour

$ build/src/vkmark --winsys-dir=build/src --data-dir=data -d
Debug: WindowSystemLoader: Looking in build/src for window system plugins
Debug: WindowSystemLoader: Loading options from build/src/wayland.so... ok
Debug: WindowSystemLoader: Loading options from build/src/xcb.so... ok
Debug: WindowSystemLoader: Loading options from build/src/kms.so... ok
Debug: WindowSystemLoader: Probing build/src/wayland.so... succeeded with priority 255
Debug: WindowSystemLoader: Probing build/src/xcb.so... succeeded with priority 127
Debug: WindowSystemLoader: Probing build/src/kms.so... succeeded with priority 255
Debug: WindowSystemLoader: Selected window system plugin build/src/wayland.so (best match)
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

Debug: Trying to use first supported device.
Debug: First supported device choosen!
Debug: VulkanState: Using queue family index 0 for WSI operations
Debug: VulkanState: Using queue family index 0 for rendering
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Unorm
Debug: SwapchainWindowSystem: Selected swapchain format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Swapchain contains 4 images
Info: =======================================================
Info:     vkmark 2017.08
Info: =======================================================
Info:     Vendor ID:      0x8086
Info:     Device ID:      0x1912
Info:     Device Name:    Intel(R) HD Graphics 530 (SKL GT2)
Info:     Driver Version: 83898372
Info:     Device UUID:    0917cee108e56b561dfc7310d928c8e0
Info: =======================================================
Info: [vertex] device-local=true:^C FPS: 7466 FrameTime: 0.134 ms
Info: =======================================================
Info:                                    vkmark Score: 7466
Info: =======================================================

# listing devices

$ build/src/vkmark --winsys-dir=build/src --data-dir=data -d -L
Debug: WindowSystemLoader: Looking in build/src for window system plugins
Debug: WindowSystemLoader: Loading options from build/src/wayland.so... ok
Debug: WindowSystemLoader: Loading options from build/src/xcb.so... ok
Debug: WindowSystemLoader: Loading options from build/src/kms.so... ok
Debug: WindowSystemLoader: Probing build/src/wayland.so... succeeded with priority 255
Debug: WindowSystemLoader: Probing build/src/xcb.so... succeeded with priority 127
Debug: WindowSystemLoader: Probing build/src/kms.so... succeeded with priority 255
Debug: WindowSystemLoader: Selected window system plugin build/src/wayland.so (best match)
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

Debug: Trying to use first supported device.
Debug: First supported device choosen!
Debug: VulkanState: Using queue family index 0 for WSI operations
Debug: VulkanState: Using queue family index 0 for rendering
Info: === Physical Device 0. ===
Info:     Vendor ID:      0x8086
Info:     Device ID:      0x1912
Info:     Device Name:    Intel(R) HD Graphics 530 (SKL GT2)
Info:     Driver Version: 83898372
Info:     Device UUID:    0917cee108e56b561dfc7310d928c8e0
Info: === Physical Device 1. ===
Info:     Vendor ID:      0x1002
Info:     Device ID:      0x731F
Info:     Device Name:    AMD RADV NAVI10 (ACO)
Info:     Driver Version: 83898372
Info:     Device UUID:    98473725a551ca92626fc40081be0f98

# selecting integrated graphics

$ build/src/vkmark --winsys-dir=build/src --data-dir=data -d -D 0917cee108e56b561dfc7310d928c8e0
Debug: WindowSystemLoader: Looking in build/src for window system plugins
Debug: WindowSystemLoader: Loading options from build/src/wayland.so... ok
Debug: WindowSystemLoader: Loading options from build/src/xcb.so... ok
Debug: WindowSystemLoader: Loading options from build/src/kms.so... ok
Debug: WindowSystemLoader: Probing build/src/wayland.so... succeeded with priority 255
Debug: WindowSystemLoader: Probing build/src/xcb.so... succeeded with priority 127
Debug: WindowSystemLoader: Probing build/src/kms.so... succeeded with priority 255
Debug: WindowSystemLoader: Selected window system plugin build/src/wayland.so (best match)
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

Debug: Trying to use device with specified UUID 0917cee108e56b561dfc7310d928c8e0.
Debug: Device found
Debug: VulkanState: Using queue family index 0 for WSI operations
Debug: VulkanState: Using queue family index 0 for rendering
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Unorm
Debug: SwapchainWindowSystem: Selected swapchain format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Swapchain contains 4 images
Info: =======================================================
Info:     vkmark 2017.08
Info: =======================================================
Info:     Vendor ID:      0x8086
Info:     Device ID:      0x1912
Info:     Device Name:    Intel(R) HD Graphics 530 (SKL GT2)
Info:     Driver Version: 83898372
Info:     Device UUID:    0917cee108e56b561dfc7310d928c8e0
Info: =======================================================
Info: [vertex] device-local=true:^C FPS: 7381 FrameTime: 0.135 ms
Info: =======================================================
Info:                                    vkmark Score: 7381
Info: =======================================================

# selecting dedicated graphics

$ build/src/vkmark --winsys-dir=build/src --data-dir=data -d -D 98473725a551ca92626fc40081be0f98
Debug: WindowSystemLoader: Looking in build/src for window system plugins
Debug: WindowSystemLoader: Loading options from build/src/wayland.so... ok
Debug: WindowSystemLoader: Loading options from build/src/xcb.so... ok
Debug: WindowSystemLoader: Loading options from build/src/kms.so... ok
Debug: WindowSystemLoader: Probing build/src/wayland.so... succeeded with priority 255
Debug: WindowSystemLoader: Probing build/src/xcb.so... succeeded with priority 127
Debug: WindowSystemLoader: Probing build/src/kms.so... succeeded with priority 255
Debug: WindowSystemLoader: Selected window system plugin build/src/wayland.so (best match)
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

Debug: Trying to use device with specified UUID 98473725a551ca92626fc40081be0f98.
Debug: Device found
Debug: VulkanState: Using queue family index 0 for WSI operations
Debug: VulkanState: Using queue family index 0 for rendering
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Available surface format B8G8R8A8Unorm
Debug: SwapchainWindowSystem: Selected swapchain format B8G8R8A8Srgb
Debug: SwapchainWindowSystem: Swapchain contains 4 images
Info: =======================================================
Info:     vkmark 2017.08
Info: =======================================================
Info:     Vendor ID:      0x1002
Info:     Device ID:      0x731F
Info:     Device Name:    AMD RADV NAVI10 (ACO)
Info:     Driver Version: 83898372
Info:     Device UUID:    98473725a551ca92626fc40081be0f98
Info: =======================================================
Info: [vertex] device-local=true:^C FPS: 26728 FrameTime: 0.037 ms
Info: =======================================================
Info:                                    vkmark Score: 26728
Info: =======================================================

# new entries in help

  -D  --use-device            Use Vulkan device with specified UUID
  -L  --list-devices          List Vulkan devices


```
