### PR TITLE
meson: check all deps, when enabling wayland winsys

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,8 @@ if get_option('kms') == 'true' and not has_vulkan_intel_header
 endif
 
 build_xcb_ws = xcb_dep.found() and xcb_icccm_dep.found() and get_option('xcb') != 'false'
-build_wayland_ws = wayland_client_dep.found() and get_option('wayland') != 'false'
+build_wayland_ws = (wayland_client_dep.found() and wayland_protocols_dep.found() and
+                    wayland_scanner_dep.found() and get_option('wayland') != 'false')
 build_kms_ws = libdrm_dep.found() and gbm_dep.found() and has_vulkan_intel_header and get_option('kms') != 'false'
 
 subdir('src')


### PR DESCRIPTION
Currently we check only one of the three dependencies for the wayland
winsys. As such if one is missing (say wayland-protocols) meson chokes
producing interesting output:

Run-time dependency wayland-protocols found: NO (tried pkgconfig and cmake)
Run-time dependency wayland-scanner found: YES 1.19.0
...
src/meson.build:91:4: ERROR: 'not-found' is not a pkgconfig dependency

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>