### PR TITLE
Enable prefix override for cross compilation

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,7 @@
 prog_python = find_program('python3')
 
 vulkan_hpp = join_paths([
-    vulkan_dep.get_pkgconfig_variable('includedir'),
+    vulkan_dep.get_pkgconfig_variable('includedir', define_variable: ['prefix', get_option('prefix')]),
     'vulkan',
     'vulkan.hpp'
     ])


### PR DESCRIPTION
Enables cross compile via Yocto Honister.  See recipe here:  https://github.com/jwinarske/meta-vulkan/blob/main/recipes-graphics/vkmark/vkmark_git.bb

Requires patched vulkan.pc.  vulkan.pc has been incorrect since Vulkan-Loader 1.2.162.  Fix was merged into master today: https://github.com/KhronosGroup/Vulkan-Loader/pull/756

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>