### PR TITLE
Fix missing <cstdint> include

### DIFF
--- a/src/scene.h
+++ b/src/scene.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
Recently building vkmark on Fedora rawhide started failing with:
```
In file included from ../src/benchmark.cpp:25:
../src/scene.h:79:5: error: ‘uint64_t’ does not name a type
   79 |     uint64_t start_time;
      |     ^~~~~~~~
../src/scene.h:28:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

```