### PR TITLE
meson: respect sys_root components

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     ['cpp', 'c'],
     default_options : ['cpp_std=c++14'],
     version : '2017.08',
-    meson_version: '>=0.45'
+    meson_version: '>=0.56'
     )
 
 root_incdir = include_directories('.')
@@ -29,7 +29,7 @@ xcb_icccm_dep = dependency('xcb-icccm', required : get_option('xcb') == 'true')
 wayland_client_dep = dependency('wayland-client', required : get_option('wayland') == 'true')
 wayland_protocols_dep = dependency('wayland-protocols', version : '>= 1.12',
                                    required : get_option('wayland') == 'true')
-wayland_scanner_dep = dependency('wayland-scanner', required : get_option('wayland') == 'true')
+wayland_scanner_dep = dependency('wayland-scanner', required : get_option('wayland') == 'true', native: true)
 libdrm_dep = dependency('libdrm', required : get_option('kms') == 'true')
 gbm_dep = dependency('gbm', required : get_option('kms') == 'true')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,13 @@
 prog_python = find_program('python3')
 
+vulkan_inculdedir = vulkan_dep.get_variable(pkgconfig : 'includedir')
+if vulkan_inculdedir.startswith('/')
+    vulkan_inculdedir = vulkan_inculdedir.substring(1)
+endif
+
 vulkan_hpp = join_paths([
-    vulkan_dep.get_pkgconfig_variable('includedir'),
+    meson.get_external_property('sys_root', '/'),
+    vulkan_inculdedir,
     'vulkan',
     'vulkan.hpp'
     ])
@@ -87,8 +93,8 @@ if build_xcb_ws
 endif
 
 if build_wayland_ws
-    wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))
-    wayland_protocols_dir = wayland_protocols_dep.get_pkgconfig_variable('pkgdatadir')
+    wayland_scanner = find_program(wayland_scanner_dep.get_variable(pkgconfig : 'wayland_scanner'))
+    wayland_protocols_dir = wayland_protocols_dep.get_variable(pkgconfig : 'pkgdatadir')
 
     xdg_shell_xml_path = wayland_protocols_dir + '/stable/xdg-shell/xdg-shell.xml'
     xdg_shell_client_header = custom_target(


### PR DESCRIPTION
Respect sys_root component for paths fetched from pkg-config. Also use native wayland-scanner to prevent issues when cross compiling. If native isn't specified a cross-compiled binary is fetched, which will fail to execute on the host.

This requires bumping the meson version forward a bit so address the deprecated function calls.

Alternative implementation to #39 since prefix and pkg_config_libdir are both pkg-config specific variables that Yocto do not attempt to adjust.