### PR TITLE
Add unbacked window system and validation layer support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,4 +61,6 @@ if build_kms_ws
     msg += 'kms '
 endif
 
+    msg += 'nows '
+
 message(msg)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,7 @@ try
     auto&& device_strategy = options.use_device_with_uuid.second ?
         VulkanState::ChoosePhysicalDeviceStrategy{ChooseByUUIDStrategy{options.use_device_with_uuid.first}} :
         VulkanState::ChoosePhysicalDeviceStrategy{ChooseFirstSupportedStrategy{}};
-    VulkanState vulkan{ws.vulkan_wsi(), device_strategy};
+    VulkanState vulkan{ws.vulkan_wsi(), device_strategy, options.show_debug};
 
     if (options.list_devices)
     {

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ prog_python = find_program('python3')
 vulkan_hpp = join_paths([
     vulkan_dep.get_pkgconfig_variable('includedir'),
     'vulkan',
-    'vulkan.hpp'
+    'vulkan_enums.hpp'
     ])
 
 format_map_gen_h = custom_target(

--- a/src/meson.build
+++ b/src/meson.build
@@ -130,3 +130,14 @@ if build_kms_ws
         install_dir : ws_dir
         )
 endif
+
+nows_ws = shared_module(
+    'nows',
+    'ws/nows_window_system.cpp',
+    'ws/nows_window_system_plugin.cpp',
+    vkutil_sources,
+    dependencies : [vulkan_dep],
+    name_prefix : '',
+    install : true,
+    install_dir : ws_dir
+    )

--- a/src/scenes/clear_scene.h
+++ b/src/scenes/clear_scene.h
@@ -43,7 +43,6 @@ private:
 
     VulkanState* vulkan;
     std::vector<vk::CommandBuffer> command_buffers;
-    std::vector<vk::Fence> command_buffer_fences;
     ManagedResource<vk::Semaphore> submit_semaphore;
     vk::ClearColorValue clear_color;
     bool cycle;

--- a/src/scenes/cube_scene.cpp
+++ b/src/scenes/cube_scene.cpp
@@ -115,7 +115,7 @@ VulkanImage CubeScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/scenes/desktop_scene.cpp
+++ b/src/scenes/desktop_scene.cpp
@@ -251,7 +251,7 @@ VulkanImage DesktopScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/scenes/effect2d_scene.cpp
+++ b/src/scenes/effect2d_scene.cpp
@@ -144,7 +144,7 @@ VulkanImage Effect2DScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/scenes/shading_scene.cpp
+++ b/src/scenes/shading_scene.cpp
@@ -132,7 +132,7 @@ VulkanImage ShadingScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/scenes/texture_scene.cpp
+++ b/src/scenes/texture_scene.cpp
@@ -136,7 +136,7 @@ VulkanImage TextureScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/scenes/vertex_scene.cpp
+++ b/src/scenes/vertex_scene.cpp
@@ -134,7 +134,7 @@ VulkanImage VertexScene::draw(VulkanImage const& image)
         .setSignalSemaphoreCount(1)
         .setPSignalSemaphores(&submit_semaphore.raw);
 
-    vulkan->graphics_queue().submit(submit_info, {});
+    vulkan->graphics_queue().submit(submit_info, image.fence);
 
     return image.copy_with_semaphore(submit_semaphore);
 }

--- a/src/vulkan_image.h
+++ b/src/vulkan_image.h
@@ -28,7 +28,7 @@ struct VulkanImage
 {
     VulkanImage copy_with_semaphore(vk::Semaphore sem) const
     {
-        return {index, image, format, extent, sem};
+        return {index, image, format, extent, sem, fence};
     }
 
     uint32_t index;
@@ -36,4 +36,5 @@ struct VulkanImage
     vk::Format format;
     vk::Extent2D extent;
     vk::Semaphore semaphore;
+    vk::Fence fence;
 };

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -97,7 +97,8 @@ void VulkanState::log_all_devices() const
 void VulkanState::create_instance(VulkanWSI& vulkan_wsi)
 {
     auto const app_info = vk::ApplicationInfo{}
-        .setPApplicationName("vkmark");
+        .setPApplicationName("vkmark")
+        .setApiVersion(VK_MAKE_API_VERSION(0, 1, 0, 0));
 
     std::vector<char const*> enabled_extensions{vulkan_wsi.required_extensions().instance};
     enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -28,8 +28,20 @@
 #include <vector>
 #include <vulkan/vulkan.hpp>
 
+static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+    VkDebugUtilsMessageTypeFlagsEXT messageType,
+    const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
+    void* pUserData) {
 
-VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)
+    Log::debug("%s\n", pCallbackData->pMessage);
+
+    return VK_FALSE;
+}
+
+
+VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy, bool debug)
+    : debug_enabled(debug)
 {
     create_instance(vulkan_wsi);
     create_physical_device(vulkan_wsi, pd_strategy);
@@ -90,14 +102,58 @@ void VulkanState::create_instance(VulkanWSI& vulkan_wsi)
     std::vector<char const*> enabled_extensions{vulkan_wsi.required_extensions().instance};
     enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
+    std::vector<char const*> validation_layers;
+
+    bool have_debug_extensions = false;
+    if (debug_enabled)
+    {
+        std::vector<vk::LayerProperties> instanceLayerProps = vk::enumerateInstanceLayerProperties();
+
+        for (auto layer : instanceLayerProps)
+        {
+            if(strcmp(layer.layerName, "VK_LAYER_KHRONOS_validation") == 0)
+            {
+                have_debug_extensions = true;
+                validation_layers.push_back("VK_LAYER_KHRONOS_validation");
+                enabled_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+                break;
+            }
+        }
+    }
+
     auto const create_info = vk::InstanceCreateInfo{}
         .setPApplicationInfo(&app_info)
+        .setEnabledLayerCount(validation_layers.size())
+        .setPpEnabledLayerNames(validation_layers.data())
         .setEnabledExtensionCount(enabled_extensions.size())
         .setPpEnabledExtensionNames(enabled_extensions.data());
 
     vk_instance = ManagedResource<vk::Instance>{
         vk::createInstance(create_info),
         [] (auto& i) { i.destroy(); }};
+
+    if (have_debug_extensions)
+    {
+        auto const createInfo = vk::DebugUtilsMessengerCreateInfoEXT{}
+            .setMessageSeverity(vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose |
+                                vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo |
+                                vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning |
+                                vk::DebugUtilsMessageSeverityFlagBitsEXT::eError)
+            .setMessageType(vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral |
+                            vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation |
+                            vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance)
+            .setPfnUserCallback(debugCallback);
+
+        dldi = vk::DispatchLoaderDynamic{instance(), vkGetInstanceProcAddr};
+
+        debug_messenger = ManagedResource<vk::DebugUtilsMessengerEXT>{
+            instance().createDebugUtilsMessengerEXT(createInfo, nullptr, dldi),
+            [this] (auto& d) {instance().destroyDebugUtilsMessengerEXT(d, nullptr, dldi);}};
+    }
+    else
+    {
+        Log::debug("VK_LAYER_KHRONOS_validation is not supported\n");
+    }
 }
 
 void VulkanState::create_physical_device(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy)

--- a/src/vulkan_state.h
+++ b/src/vulkan_state.h
@@ -36,7 +36,7 @@ public:
     using ChoosePhysicalDeviceStrategy =
         std::function<vk::PhysicalDevice (std::vector<vk::PhysicalDevice> const&)>;
 
-    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy);
+    VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy, bool debug);
 
     vk::Instance const& instance() const
     {
@@ -85,6 +85,10 @@ private:
     vk::Queue vk_graphics_queue;
     vk::PhysicalDevice vk_physical_device;
     uint32_t vk_graphics_queue_family_index;
+
+    bool debug_enabled;
+    ManagedResource<vk::DebugUtilsMessengerEXT> debug_messenger;
+    vk::DispatchLoaderDynamic dldi;
 };
 
 class ChooseFirstSupportedStrategy

--- a/src/ws/nows_window_system.cpp
+++ b/src/ws/nows_window_system.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2024 Igalia S.L.
+ *
+ * This file is part of vkmark.
+ *
+ * vkmark is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * vkmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with vkmark. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *   Lucas Fryzek <lfryzek@igalia.com>
+ */
+
+#include "nows_window_system.h"
+
+#include "vulkan_state.h"
+#include "vulkan_image.h"
+#include "vkutil/vkutil.h"
+#include "log.h"
+
+#include <stdexcept>
+#include <algorithm>
+#include <cctype>
+
+NoWindowSystem::NoWindowSystem(
+    vk::Format pixel_format, uint32_t width, uint32_t height, uint32_t num_buffers)
+    : vk_pixel_format{pixel_format},
+      vulkan{nullptr},
+      vk_extent{width, height},
+      num_buffers{num_buffers}
+{
+}
+
+VulkanWSI& NoWindowSystem::vulkan_wsi()
+{
+    return *this;
+}
+
+void NoWindowSystem::init_vulkan(VulkanState& vulkan_)
+{
+    vulkan = &vulkan_;
+
+    vk_queue_family_index = vulkan->graphics_queue_family_index();
+    vk_queue = vulkan->device().getQueue(vk_queue_family_index, 0);
+
+    Log::debug("NoWindowSystem: Allocating %u %ux%u buffers\n",
+            num_buffers, vk_extent.width, vk_extent.height);
+
+    for (uint32_t i = 0; i < num_buffers; ++i)
+    {
+        vk_images.push_back(
+            vkutil::ImageBuilder(*vulkan)
+                .set_extent(vk_extent)
+                .set_format(vk_pixel_format)
+                .set_tiling(vk::ImageTiling::eOptimal)
+                .set_usage(vk::ImageUsageFlagBits::eColorAttachment |
+                           vk::ImageUsageFlagBits::eTransferDst)
+                .set_memory_properties(vk::MemoryPropertyFlagBits::eDeviceLocal)
+                .set_initial_layout(vk::ImageLayout::eUndefined)
+                .build()
+        );
+
+        vkutil::transition_image_layout(
+                *vulkan,
+                vk_images[i],
+                vk::ImageLayout::eUndefined,
+                vk::ImageLayout::eColorAttachmentOptimal,
+                vk::ImageAspectFlagBits::eColor);
+
+        vk_acquire_fences.push_back(ManagedResource<vk::Fence>{
+            vulkan->device().createFence(vk::FenceCreateInfo(vk::FenceCreateFlagBits::eSignaled)),
+            [this] (auto& f) {vulkan->device().destroyFence(f); }});
+    }
+
+    vk_semaphore = nullptr;
+    current_frame = 0;
+}
+
+void NoWindowSystem::deinit_vulkan()
+{
+    vulkan->device().waitIdle();
+    vk_semaphore = nullptr;
+    vk_images.clear();
+    vk_acquire_fences.clear();
+}
+
+VulkanImage NoWindowSystem::next_vulkan_image()
+{
+    vulkan->device().waitForFences(vk_acquire_fences[current_frame].raw, true, INT64_MAX);
+    vulkan->device().resetFences(vk_acquire_fences[current_frame].raw);
+    return {current_frame, vk_images[current_frame], vk_pixel_format, vk_extent, vk_semaphore, vk_acquire_fences[current_frame]};
+}
+
+void NoWindowSystem::present_vulkan_image(VulkanImage const& vulkan_image)
+{
+    vk_semaphore = vulkan_image.semaphore;
+    current_frame = (current_frame + 1) % vk_images.size();
+}
+
+std::vector<VulkanImage> NoWindowSystem::vulkan_images()
+{
+    std::vector<VulkanImage> vulkan_images;
+
+    for (uint32_t i = 0; i < vk_images.size(); ++i)
+    {
+        vulkan_images.push_back({i, vk_images[i], vk_pixel_format, vk_extent, {}, {}});
+    }
+
+    vk_semaphore = nullptr;
+    return vulkan_images;
+}
+
+bool NoWindowSystem::should_quit()
+{
+    return false;
+}
+
+VulkanWSI::Extensions NoWindowSystem::required_extensions()
+{
+    return {{}, {VK_KHR_SWAPCHAIN_EXTENSION_NAME}};
+}
+
+bool NoWindowSystem::is_physical_device_supported(vk::PhysicalDevice const& pd)
+{
+    return true;
+}
+
+std::vector<uint32_t> NoWindowSystem::physical_device_queue_family_indices(
+    vk::PhysicalDevice const& pd)
+{
+    return {};
+}

--- a/src/ws/nows_window_system.h
+++ b/src/ws/nows_window_system.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2024 Igalia S.L.
+ *
+ * This file is part of vkmark.
+ *
+ * vkmark is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * vkmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with vkmark. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *   Lucas Fryzek <lfryzek@igalia.com>
+ */
+
+# pragma once
+
+#include "window_system.h"
+#include "vulkan_wsi.h"
+#include "managed_resource.h"
+
+#include <memory.h>
+#include <vulkan/vulkan.hpp>
+
+class NativeSystem;
+
+class NoWindowSystem : public WindowSystem, VulkanWSI
+{
+public:
+    NoWindowSystem(
+            vk::Format pixel_format, uint32_t width, uint32_t height, uint32_t num_buffers);
+
+    VulkanWSI& vulkan_wsi() override;
+    void init_vulkan(VulkanState& vulkan) override;
+    void deinit_vulkan() override;
+
+    VulkanImage next_vulkan_image() override;
+    void present_vulkan_image(VulkanImage const&) override;
+    std::vector<VulkanImage> vulkan_images() override;
+
+    bool should_quit() override;
+
+    // VulkanWSI
+    Extensions required_extensions() override;
+    bool is_physical_device_supported(vk::PhysicalDevice const& pd) override;
+    std::vector<uint32_t> physical_device_queue_family_indices(
+        vk::PhysicalDevice const& pd) override;
+private:
+    vk::Format const vk_pixel_format;
+    VulkanState* vulkan;
+    uint32_t vk_queue_family_index;
+    vk::Queue vk_queue;
+    uint32_t current_frame;
+    vk::Semaphore vk_semaphore;
+    std::vector<ManagedResource<vk::Fence>> vk_acquire_fences;
+    std::vector<ManagedResource<vk::Image>> vk_images;
+    vk::Extent2D vk_extent;
+    uint32_t num_buffers;
+};

--- a/src/ws/nows_window_system_plugin.cpp
+++ b/src/ws/nows_window_system_plugin.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2024 Igalia S.L.
+ *
+ * This file is part of vkmark.
+ *
+ * vkmark is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * vkmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with vkmark. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *   Lucas Fryzek <lfryzek@igalia.com>
+ */
+
+#include "window_system_plugin.h"
+#include "nows_window_system.h"
+
+#include "options.h"
+
+std::string const width_opt{"width"};
+std::string const height_opt{"height"};
+std::string const num_buffers_opt{"num-buffers"};
+
+static uint32_t get_int_option(Options const& options, std::string const& option_name, uint32_t default_value)
+{
+    auto const& winsys_options = options.window_system_options;
+
+    for (auto const& opt : winsys_options)
+    {
+        if (opt.name == option_name)
+        {
+            try {
+                return std::stoi(opt.value);
+            } catch ( ... ) {
+                throw std::runtime_error{"Invalid value '" + opt.value + "' for option '" + option_name + "'"};
+            }
+        }
+    }
+
+    return default_value;
+}
+
+void vkmark_window_system_load_options(Options& options)
+{
+    options.add_window_system_help(
+        "No window system options (pass in --winsys-options)\n"
+        "  width=X          Buffer width to use\n"
+        "  height=X         Buffer height to use\n"
+        "  num-buffers=X    Number of offscreen buffers to allocate\n"
+        );
+}
+
+int vkmark_window_system_probe(Options const&)
+{
+    return 1;
+}
+
+std::unique_ptr<WindowSystem> vkmark_window_system_create(Options const& options)
+{
+    auto pixel_format = options.pixel_format;
+    if (options.pixel_format == vk::Format::eUndefined)
+        pixel_format = vk::Format::eR8G8B8A8Srgb;
+    return std::make_unique<NoWindowSystem>(
+            pixel_format,
+            get_int_option(options, width_opt, 512),
+            get_int_option(options, height_opt, 512),
+            get_int_option(options, num_buffers_opt, 3));
+}

--- a/src/ws/swapchain_window_system.h
+++ b/src/ws/swapchain_window_system.h
@@ -68,8 +68,11 @@ private:
     vk::Queue vk_present_queue;
     ManagedResource<vk::SurfaceKHR> vk_surface;
     ManagedResource<vk::SwapchainKHR> vk_swapchain;
-    ManagedResource<vk::Semaphore> vk_acquire_semaphore;
+    std::vector<ManagedResource<vk::Semaphore>> vk_acquire_semaphores;
+    std::vector<ManagedResource<vk::Fence>> vk_acquire_fences;
     std::vector<vk::Image> vk_images;
+    uint32_t current_frame;
+    uint32_t image_index;
     vk::Format vk_image_format;
     vk::Extent2D vk_extent;
 };


### PR DESCRIPTION
I was trying to run vkmark on a system where I didn't have a display connected, so I created a new unbacked window system that directly render to  images that are never displayed.

While setting up this new window system I ran into a few issues, so I also added support for loading vulkan validation layers. If vkmark is launched with the debug flag and the validation layers are found, it will now use them and log any validation errors. I also resolved any of the validation errors that came up in the existing scenes. The main issue to fix was a sync issue for swapbuffer, where the semaphore being used for AcquireNextImageKHR was in a pending state since we never had a fence to wait on before calling `AcquireNextImageKHR`.