### PR TITLE
Add missing newline to scene debug info.

### DIFF
--- a/src/main_loop.cpp
+++ b/src/main_loop.cpp
@@ -36,7 +36,7 @@ namespace
 
 void log_scene_info(Scene& scene, bool show_all_options)
 {
-    Log::info("%s", scene.info_string(show_all_options).c_str());
+    Log::info("%s\n", scene.info_string(show_all_options).c_str());
     Log::flush();
 }
 


### PR DESCRIPTION
A trivial change, but without it, the next debug line is appended to the end of the scene info when using --debug.