### PR TITLE
shading: Add missing fragment stage flag for uniform descriptor set

### DIFF
--- a/src/scenes/shading_scene.cpp
+++ b/src/scenes/shading_scene.cpp
@@ -208,7 +208,8 @@ void ShadingScene::setup_uniform_descriptor_sets()
         descriptor_sets.push_back(
             vkutil::DescriptorSetBuilder{*vulkan}
                 .set_type(vk::DescriptorType::eUniformBuffer)
-                .set_stage_flags(vk::ShaderStageFlagBits::eVertex)
+                .set_stage_flags(vk::ShaderStageFlagBits::eVertex |
+                                 vk::ShaderStageFlagBits::eFragment)
                 .set_buffer(uniform_buffer, 0, sizeof(Uniforms))
                 .set_layout_out(descriptor_set_layout)
                 .build()


### PR DESCRIPTION
In https://github.com/vkmark/vkmark/commit/fd2d79800dba2d4814265ca4f934e17cbfc97b70, VK_SHADER_STAGE_FRAGMENT_BIT was omitted for uniform descriptor set in shading_scene, which causes regression on AMD cards with Pro driver (LLPC).