### PR TITLE
src/meson.build: revert to older form to find vx.xml

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,8 +1,9 @@
 prog_python = find_program('python3')
 
+vulkan_prefix = meson.get_external_property('sys_root', '') + vulkan_dep.get_variable('prefix')
+
 vk_xml = join_paths([
-    meson.get_external_property('sys_root', ''),
-    vulkan_dep.get_variable('prefix'),
+    vulkan_prefix,
     'share', 'vulkan', 'registry',
     'vk.xml'
     ])


### PR DESCRIPTION
The last minute upstream change #76 to compute the sys_root inside of join_paths broke cross compilation. This is because the behaviour of join_paths is to override the built up path when an absolute path is in place. As a result we see:

  sysroot -> /home/alex/lsrc/tests/buildroot.git/builds/arm64/host/aarch64-buildroot-linux-gnu/sysroot
  prefix -> /usr

then the final path becomes:

  /usr/share/vulkan/registry/vk.xml

I think the longer term solution would be to propose the registry path is exported by vulkan itself so the vkmark meson.build doesn't have to play these games.