### PR TITLE
meson: Enable devenv support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,11 @@ subdir('data')
 subdir('tests')
 subdir('doc')
 
+devenv = environment()
+devenv.set('VKMARK_WINDOW_SYSTEM_DIR', meson.current_build_dir() / 'src')
+devenv.set('VKMARK_DATA_DIR', meson.current_source_dir() / 'data')
+meson.add_devenv(devenv)
+
 msg = 'Building with support for the following window systems: headless display '
 
 if build_wayland_ws

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -20,6 +20,7 @@
  *   Alexandros Frantzis <alexandros.frantzis@collabora.com>
  */
 
+#include <cstdlib>
 #include <cstdio>
 #include <getopt.h>
 #include <algorithm>
@@ -141,6 +142,13 @@ Options::Options()
       list_devices{false},
       use_device_with_uuid{}
 {
+    const char* var;
+    var = getenv("VKMARK_WINDOW_SYSTEM_DIR");
+    if (var)
+        window_system_dir = var;
+    var = getenv("VKMARK_DATA_DIR");
+    if (var)
+        data_dir = var;
 }
 
 std::string Options::help_string()


### PR DESCRIPTION
This means vkmark can be run from a cloned repo with:
```bash
meson setup _build
meson compile -C _build
meson devenv -C _build
vkmark
```

This adds the environment variables `VKMARK_WINDOW_SYSTEM_DIR` and `VKMARK_DATA_DIR` which set the `winsys-dir` and `data-dir` args. These are set by `meson devenv` to allow the benches to be run without installation.